### PR TITLE
GM-93 중고거래 게시글 추가

### DIFF
--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
@@ -1,0 +1,40 @@
+package com.gaaji.useditem.applicationservice;
+
+import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.domain.Post;
+import com.gaaji.useditem.domain.Price;
+import com.gaaji.useditem.domain.PurchaserId;
+import com.gaaji.useditem.domain.SellerId;
+import com.gaaji.useditem.domain.Town;
+import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import com.gaaji.useditem.domain.WishPlace;
+import com.gaaji.useditem.repository.UsedItemPostRepository;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UsedItemPostCreateService {
+
+    private final UsedItemPostRepository usedItemPostRepository;
+
+    public String createUsedItemPost(PostCreateRequest dto) {
+
+        UsedItemPost usedItemPost = UsedItemPost.of(UsedItemPostId.of(usedItemPostRepository.nextId())
+                , SellerId.of(dto.getAuthId()),
+                Post.of(dto.getTitle(), dto.getContents(), dto.getCategory())
+                , Price.of(dto.getPrice()), dto.getCanSuggest(),
+                WishPlace.of(dto.getPlaceX(), dto.getPlaceY(), dto.getPlaceText())
+                , PurchaserId.of(null), Town.of(dto.getTownId(), dto.getAddress()),
+                Collections.emptyList()
+        );
+
+        usedItemPostRepository.save(usedItemPost);
+
+        return usedItemPost.getUsedItemPostId();
+    }
+}

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostCreateController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostCreateController.java
@@ -1,0 +1,33 @@
+package com.gaaji.useditem.controller;
+
+import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
+import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.controller.dto.PostCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class UsedItemPostCreateController {
+
+    private final UsedItemPostCreateService usedItemPostCreateService;
+
+    @PostMapping("/posts")
+    public ResponseEntity<PostCreateResponse> createUsedItemPost(@RequestHeader(HttpHeaders.AUTHORIZATION)
+    String authorization,
+            @RequestHeader("X-TOWN-TOKEN") String townToken
+            , @RequestBody PostCreateRequest dto
+    ) {
+        dto.injectHeaderInfo(authorization,townToken);
+        String postId = usedItemPostCreateService.createUsedItemPost(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new PostCreateResponse(postId));
+    }
+
+
+}

--- a/src/main/java/com/gaaji/useditem/controller/dto/PostCreateRequest.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostCreateRequest.java
@@ -1,0 +1,38 @@
+package com.gaaji.useditem.controller.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class PostCreateRequest {
+
+    private String title;
+    private String contents;
+    private String category;
+    private Boolean canSuggest;
+    private Long price;
+    private String placeX;
+    private String placeY;
+    private String placeText;
+
+    private String authId;
+    private String townId;
+    private String address;
+
+    public void injectHeaderInfo(String authId, String townHeader){
+        this.authId = authId;
+        TownToken townToken = null;
+        try {
+             townToken = new ObjectMapper().readValue(townHeader, TownToken.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        this.townId = townToken.getTownId();
+        this.address = townToken.getAddress();
+    }
+}

--- a/src/main/java/com/gaaji/useditem/controller/dto/PostCreateResponse.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostCreateResponse.java
@@ -1,0 +1,14 @@
+package com.gaaji.useditem.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PostCreateResponse {
+
+    private String postId;
+
+
+}

--- a/src/main/java/com/gaaji/useditem/controller/dto/TownToken.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/TownToken.java
@@ -1,0 +1,14 @@
+package com.gaaji.useditem.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class TownToken {
+    private String townId;
+    private String address;
+
+}

--- a/src/main/java/com/gaaji/useditem/domain/Post.java
+++ b/src/main/java/com/gaaji/useditem/domain/Post.java
@@ -1,9 +1,13 @@
 package com.gaaji.useditem.domain;
 
+import com.gaaji.useditem.exception.InputNullDataOnCategoryException;
+import com.gaaji.useditem.exception.InputNullDataOnTitleException;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +28,9 @@ public class Post {
         this.isHide = false;
     }
     public static Post of(String title, String contents, String category){
+        if(!StringUtils.hasText(title)) throw new InputNullDataOnTitleException();
+        if(!StringUtils.hasText(category)) throw new InputNullDataOnCategoryException();
+
         return new Post(title,contents,category);
     }
 
@@ -31,4 +38,22 @@ public class Post {
         isHide = !isHide;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Post post = (Post) o;
+        return isHide == post.isHide && Objects.equals(title, post.title)
+                && Objects.equals(contents, post.contents) && Objects.equals(
+                category, post.category) && Objects.equals(createdAt, post.createdAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, contents, category, createdAt, isHide);
+    }
 }

--- a/src/main/java/com/gaaji/useditem/domain/Price.java
+++ b/src/main/java/com/gaaji/useditem/domain/Price.java
@@ -1,5 +1,7 @@
 package com.gaaji.useditem.domain;
 
+import com.gaaji.useditem.exception.InputNullDataOnPriceException;
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,6 +15,26 @@ public class Price {
     private Long price;
 
     public static Price of(Long price){
+        if (price == null || price < 0) throw new InputNullDataOnPriceException();
         return new Price(price);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Price price1 = (Price) o;
+        return Objects.equals(price, price1.price);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(price);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/PurchaserId.java
+++ b/src/main/java/com/gaaji/useditem/domain/PurchaserId.java
@@ -1,5 +1,6 @@
 package com.gaaji.useditem.domain;
 
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,5 +15,22 @@ public class PurchaserId {
 
     public static PurchaserId of(String id) {
         return new PurchaserId(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PurchaserId that = (PurchaserId) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/SellerId.java
+++ b/src/main/java/com/gaaji/useditem/domain/SellerId.java
@@ -1,9 +1,12 @@
 package com.gaaji.useditem.domain;
 
+import com.gaaji.useditem.exception.InputNullDataOnSellerIdException;
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,6 +16,24 @@ public class SellerId {
     private String id;
 
     public static SellerId of(String id) {
+        if(!StringUtils.hasText(id)) throw new InputNullDataOnSellerIdException();
         return new SellerId(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SellerId sellerId = (SellerId) o;
+        return Objects.equals(id, sellerId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/Town.java
+++ b/src/main/java/com/gaaji/useditem/domain/Town.java
@@ -1,9 +1,13 @@
 package com.gaaji.useditem.domain;
 
+import com.gaaji.useditem.exception.InputNullDataOnAddressException;
+import com.gaaji.useditem.exception.InputNullDataOnTownIdException;
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,6 +17,25 @@ public class Town {
     private String address;
 
     public static Town of(String id, String address){
+        if (!StringUtils.hasText(id))  throw new InputNullDataOnTownIdException();
+        if (!StringUtils.hasText(address)) throw new InputNullDataOnAddressException();
         return new Town(id, address);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Town town = (Town) o;
+        return Objects.equals(id, town.id) && Objects.equals(address, town.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, address);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -2,6 +2,7 @@ package com.gaaji.useditem.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.AttributeOverride;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -75,5 +76,32 @@ public class UsedItemPost {
 
     public void reverseHide(){
         post.reverseHide();
+    }
+
+    public String getUsedItemPostId() {
+        return postId.getId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UsedItemPost that = (UsedItemPost) o;
+        return canSuggest == that.canSuggest && Objects.equals(postId, that.postId)
+                && Objects.equals(sellerId, that.sellerId) && Objects.equals(post,
+                that.post) && Objects.equals(price, that.price) && Objects.equals(
+                wishPlace, that.wishPlace) && tradeStatus == that.tradeStatus
+                && Objects.equals(purchaserId, that.purchaserId) && Objects.equals(
+                town, that.town) && Objects.equals(pictures, that.pictures);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(postId, sellerId, post, price, canSuggest, wishPlace, tradeStatus,
+                purchaserId, town, pictures);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPostId.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPostId.java
@@ -1,13 +1,17 @@
 package com.gaaji.useditem.domain;
 
+import com.gaaji.useditem.exception.InputNullDataOnPostIdException;
 import java.io.Serializable;
-import javax.persistence.AttributeOverride;
-import javax.persistence.Column;
+import java.util.Objects;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
+@Access(AccessType.FIELD)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
@@ -15,7 +19,29 @@ public class UsedItemPostId implements Serializable {
 
     private String id;
 
+    public String getId(){
+        return id;
+    }
+
     public static UsedItemPostId of(String id) {
+        if(!StringUtils.hasText(id)) throw new InputNullDataOnPostIdException();
         return new UsedItemPostId(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UsedItemPostId that = (UsedItemPostId) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/WishPlace.java
+++ b/src/main/java/com/gaaji/useditem/domain/WishPlace.java
@@ -1,5 +1,6 @@
 package com.gaaji.useditem.domain;
 
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,5 +17,23 @@ public class WishPlace {
 
     public static WishPlace of(String placeX, String placeY, String placeText) {
         return new WishPlace(placeX,placeY,placeText);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WishPlace wishPlace = (WishPlace) o;
+        return Objects.equals(placeX, wishPlace.placeX) && Objects.equals(placeY,
+                wishPlace.placeY) && Objects.equals(placeText, wishPlace.placeText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(placeX, placeY, placeText);
     }
 }

--- a/src/main/java/com/gaaji/useditem/exception/AbstractApiException.java
+++ b/src/main/java/com/gaaji/useditem/exception/AbstractApiException.java
@@ -11,7 +11,7 @@ public abstract class AbstractApiException extends RuntimeException implements E
     private final String errorName;
     private final String errorMessage;
 
-    protected AbstractApiException (ErrorCode errorCode) {
+    public AbstractApiException (ErrorCode errorCode) {
 
         httpStatus = errorCode.getHttpStatus();
         this.errorCode = errorCode.getErrorCode();

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnAddressException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnAddressException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_ADDRESS;
+
+public class InputNullDataOnAddressException extends AbstractApiException{
+
+    public InputNullDataOnAddressException() {
+        super(INPUT_NULL_DATA_ON_ADDRESS);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnCategoryException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnCategoryException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_CATEGORY;
+
+public class InputNullDataOnCategoryException extends AbstractApiException{
+
+    public InputNullDataOnCategoryException() {
+        super(INPUT_NULL_DATA_ON_CATEGORY);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnPostIdException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnPostIdException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_POST_ID;
+
+public class InputNullDataOnPostIdException extends AbstractApiException{
+
+    public InputNullDataOnPostIdException() {
+        super(INPUT_NULL_DATA_ON_POST_ID);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnPriceException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnPriceException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_PRICE;
+
+public class InputNullDataOnPriceException extends AbstractApiException{
+
+    public InputNullDataOnPriceException() {
+        super(INPUT_NULL_DATA_ON_PRICE);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnSellerIdException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnSellerIdException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_SELLER_ID;
+
+public class InputNullDataOnSellerIdException extends AbstractApiException{
+
+    public InputNullDataOnSellerIdException() {
+        super(INPUT_NULL_DATA_ON_SELLER_ID);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnTitleException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnTitleException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_TITLE;
+
+public class InputNullDataOnTitleException extends AbstractApiException {
+
+    public InputNullDataOnTitleException() {
+        super(INPUT_NULL_DATA_ON_TITLE);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/InputNullDataOnTownIdException.java
+++ b/src/main/java/com/gaaji/useditem/exception/InputNullDataOnTownIdException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.INPUT_NULL_DATA_ON_TOWN_ID;
+
+public class InputNullDataOnTownIdException extends AbstractApiException{
+
+    public InputNullDataOnTownIdException() {
+        super(INPUT_NULL_DATA_ON_TOWN_ID);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
+++ b/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
@@ -8,6 +8,27 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UsedItemErrorCode implements ErrorCode {
 
+    INPUT_NULL_DATA_ON_POST_ID(HttpStatus.INTERNAL_SERVER_ERROR, "u-0001",
+            "중고거래 데이터 생성 과정에서 PostId에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_SELLER_ID(HttpStatus.INTERNAL_SERVER_ERROR, "u-0002",
+            "중고거래 데이터 생성 과정에서 sellerId에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_TITLE(HttpStatus.INTERNAL_SERVER_ERROR, "u-0003",
+            "중고거래 데이터 생성 과정에서 Post.Title에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_CATEGORY(HttpStatus.INTERNAL_SERVER_ERROR, "u-0004",
+            "중고거래 데이터 생성 과정에서 Post.Category에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_PRICE(HttpStatus.INTERNAL_SERVER_ERROR, "u-0005",
+            "중고거래 데이터 생성 과정에서 Price에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_TOWN_ID(HttpStatus.INTERNAL_SERVER_ERROR, "u-0006",
+            "중고거래 데이터 생성 과정에서 Town.id에 Null이 입력되었습니다."),
+
+    INPUT_NULL_DATA_ON_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "u-0007",
+            "중고거래 데이터 생성 과정에서 Town.address에 Null이 입력되었습니다.")
+
 	
     ;
 	

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepository.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepository.java
@@ -1,5 +1,17 @@
 package com.gaaji.useditem.repository;
 
+import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface UsedItemPostRepository {
 
+    Optional<UsedItemPost> findByPostId(UsedItemPostId postId);
+
+    default String nextId(){
+        return UUID.randomUUID().toString();
+    }
+
+    void save(UsedItemPost usedItemPost);
 }

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepositoryImpl.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepositoryImpl.java
@@ -1,5 +1,8 @@
 package com.gaaji.useditem.repository;
 
+import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +13,13 @@ public class UsedItemPostRepositoryImpl implements
 
     private final JpaUsedItemPostRepository jpaUsedItemPostRepository;
 
+    @Override
+    public Optional<UsedItemPost> findByPostId(UsedItemPostId postId) {
+        return jpaUsedItemPostRepository.findById(postId);
+    }
+
+    @Override
+    public void save(UsedItemPost usedItemPost) {
+        jpaUsedItemPostRepository.save(usedItemPost);
+    }
 }

--- a/src/test/java/com/gaaji/useditem/domain/FakeUsedItemPostRepository.java
+++ b/src/test/java/com/gaaji/useditem/domain/FakeUsedItemPostRepository.java
@@ -1,0 +1,21 @@
+package com.gaaji.useditem.domain;
+
+import com.gaaji.useditem.repository.UsedItemPostRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeUsedItemPostRepository implements UsedItemPostRepository {
+
+    private Map<UsedItemPostId, UsedItemPost> storage = new HashMap<>();
+
+    @Override
+    public Optional<UsedItemPost> findByPostId(UsedItemPostId postId) {
+        return Optional.ofNullable(storage.get(postId));
+    }
+
+    @Override
+    public void save(UsedItemPost usedItemPost) {
+        storage.put(UsedItemPostId.of(usedItemPost.getUsedItemPostId()), usedItemPost);
+    }
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateControllerTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateControllerTest.java
@@ -1,0 +1,69 @@
+package com.gaaji.useditem.domain;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
+import com.gaaji.useditem.controller.UsedItemPostCreateController;
+import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.controller.dto.TownToken;
+import com.sun.xml.bind.v2.TODO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest
+class UsedItemPostCreateControllerTest {
+    
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UsedItemPostCreateService usedItemPostCreateService;
+
+    @InjectMocks
+    UsedItemPostCreateController usedItemPostCreateController;
+    
+    
+    @Test
+    void 정상생성 () throws Exception{
+        //given
+        BDDMockito.given(usedItemPostCreateService
+                .createUsedItemPost(ArgumentMatchers.any()))
+                .willReturn("foo");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
+                ,"foo","bar","foobar");
+        TownToken townToken = new TownToken("foo","bar");
+
+
+        //when
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/posts")
+                .header(HttpHeaders.AUTHORIZATION, "authorization")
+                .header("X-TOWN-TOKEN", new ObjectMapper().writeValueAsString(townToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(dto)));
+        //then
+            result
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.postId",is("foo")))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
@@ -1,0 +1,127 @@
+package com.gaaji.useditem.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
+import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.exception.InputNullDataOnAddressException;
+import com.gaaji.useditem.exception.InputNullDataOnCategoryException;
+import com.gaaji.useditem.exception.InputNullDataOnPriceException;
+import com.gaaji.useditem.exception.InputNullDataOnSellerIdException;
+import com.gaaji.useditem.exception.InputNullDataOnTitleException;
+import com.gaaji.useditem.exception.InputNullDataOnTownIdException;
+import com.gaaji.useditem.repository.UsedItemPostRepository;
+
+import org.junit.jupiter.api.Test;
+
+class UsedItemPostCreateServiceTest {
+
+    @Test
+    void 정상_생성 () throws Exception{
+        //given
+
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
+        ,"foo","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+
+        //when
+        String postId = service.createUsedItemPost(dto);
+        UsedItemPost usedItemPost = usedItemPostRepository.findByPostId(UsedItemPostId.of(postId))
+                .orElseThrow();
+        //then
+        assertThat(usedItemPost).isNotNull();
+        assertThat(usedItemPost.getUsedItemPostId()).isEqualTo(postId);
+    }
+    @Test
+    void 예외_제목X () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("","contents","category",true,1000L, null,null,null
+                ,"foo","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnTitleException.class);
+    }
+    @Test
+    void 예외_카테고리X () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("title","contents","",true,1000L, null,null,null
+                ,"foo","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnCategoryException.class);
+    
+    }
+    
+    @Test
+    void 예외_가격X () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,null, null,null,null
+                ,"foo","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnPriceException.class);
+    }
+
+    @Test
+    void 예외_가격_음수 () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,-2000L, null,null,null
+                ,"foo","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnPriceException.class);
+    }
+
+
+    @Test
+    void 예외_판매자ID () throws Exception{
+        //given
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
+                ,"","bar","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnSellerIdException.class);
+    }
+    @Test
+    void 예외_동네ID () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
+                ,"foo","","foobar");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnTownIdException.class);
+    }
+    @Test
+    void 예외_동네주소 () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
+                ,"foo","bar","");
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        //when // then
+        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+                .isInstanceOf(InputNullDataOnAddressException.class);
+    }
+
+
+
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostRepositoryJpaTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostRepositoryJpaTest.java
@@ -1,0 +1,41 @@
+package com.gaaji.useditem.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gaaji.useditem.repository.JpaUsedItemPostRepository;
+import java.util.Collections;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class UsedItemPostRepositoryJpaTest {
+
+    @Autowired
+    JpaUsedItemPostRepository jpaUsedItemPostRepository;
+    
+    
+    @Test
+    void 저장_조회하기 () throws Exception{
+        //given
+
+        UsedItemPost usedItemPost = UsedItemPost.of(
+                UsedItemPostId.of("foo"),
+                SellerId.of("bar")
+                , Post.of("title", "contents", "category"), Price.of(1000L)
+                ,true, null, null, Town.of("townID", "address")
+                , Collections.emptyList()
+        );
+
+        //when
+        jpaUsedItemPostRepository.save(usedItemPost);
+        UsedItemPost find = jpaUsedItemPostRepository.findById(UsedItemPostId.of("foo"))
+                .get();
+
+        //then
+        assertThat(usedItemPost).isEqualTo(find);
+    
+    }
+
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
@@ -1,0 +1,96 @@
+package com.gaaji.useditem.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gaaji.useditem.exception.InputNullDataOnAddressException;
+import com.gaaji.useditem.exception.InputNullDataOnCategoryException;
+import com.gaaji.useditem.exception.InputNullDataOnPostIdException;
+import com.gaaji.useditem.exception.InputNullDataOnPriceException;
+import com.gaaji.useditem.exception.InputNullDataOnSellerIdException;
+import com.gaaji.useditem.exception.InputNullDataOnTitleException;
+import com.gaaji.useditem.exception.InputNullDataOnTownIdException;
+import java.util.Collections;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UsedItemPostTest {
+
+    
+    @Test
+    void 정상_생성 () throws Exception{
+        //given
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        PurchaserId purchaserId = PurchaserId.of(null);
+        Town town = Town.of("foo", "bar");
+
+        //when
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest, wishPlace,
+                purchaserId, town,
+                Collections.emptyList());
+
+        //then
+        assertThat(usedItemPost).isNotNull();
+
+    }
+
+    @Test
+    void 예외_글ID_존재X () throws Exception{
+        //when
+        assertThatThrownBy(
+                () ->  UsedItemPostId.of(null))
+                .isInstanceOf(InputNullDataOnPostIdException.class);
+
+        
+        //then
+    }
+    @Test
+    void 예외_판매자ID_존재X () throws Exception{
+
+        assertThatThrownBy(
+                () ->  SellerId.of(""))
+                .isInstanceOf(InputNullDataOnSellerIdException.class);
+
+    }
+    @Test
+    void 예외_게시글_제목_존재X () throws Exception{
+        assertThatThrownBy(
+                () ->  Post.of("","","foo"))
+                .isInstanceOf(InputNullDataOnTitleException.class);
+    }
+    @Test
+    void 예외_게시글_카테고리_존재X () throws Exception{
+        assertThatThrownBy(
+                () ->  Post.of("foo","",null))
+                .isInstanceOf(InputNullDataOnCategoryException.class);
+    }
+    @Test
+    void 예외_가격_존재X_Null () throws Exception{
+        assertThatThrownBy(
+                () ->  Price.of(null))
+                .isInstanceOf(InputNullDataOnPriceException.class);
+    }
+    @Test
+    void 예외_가격_존재X_음수 () throws Exception{
+        assertThatThrownBy(
+                () ->  Price.of(-1000L))
+                .isInstanceOf(InputNullDataOnPriceException.class);
+    }
+
+    @Test
+    void 예외_동네ID_존재X () throws Exception{
+        assertThatThrownBy(
+                () ->  Town.of(null, "foo"))
+                .isInstanceOf(InputNullDataOnTownIdException.class);
+    }
+    @Test
+    void 예외_동네주소_존재X () throws Exception{
+        assertThatThrownBy(
+                () ->  Town.of("foo", null))
+                .isInstanceOf(InputNullDataOnAddressException.class);
+    }
+}


### PR DESCRIPTION
### 개요 
중고거래 게시글 추가 기능을 만들었음.
시나리오는 알다시피 진행.

### 결과
postman - 객체를 생성하면 ID 반환
![image](https://user-images.githubusercontent.com/76154390/212870536-631a4212-162b-445a-a3d4-8380bf0fb5bd.png)

db 저장 상태
![image](https://user-images.githubusercontent.com/76154390/212870637-0e8b1e6d-3951-402d-b50c-b11b4e745c46.png)

### 진행예정

GM-96 팩토리 메서드 수정
GM-105 중고거래 게시글 추가될 때 카운터 객체도 생성