### PR TITLE
GM-96 중고거래 게시글 팩토리 메서드 파라미터 수정

### DIFF
--- a/src/main/java/com/gaaji/useditem/applicationservice/Sample.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/Sample.java
@@ -1,5 +1,0 @@
-package com.gaaji.useditem.applicationservice;
-
-public class Sample {
-
-}

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
@@ -29,7 +29,7 @@ public class UsedItemPostCreateService {
                 Post.of(dto.getTitle(), dto.getContents(), dto.getCategory())
                 , Price.of(dto.getPrice()), dto.getCanSuggest(),
                 WishPlace.of(dto.getPlaceX(), dto.getPlaceY(), dto.getPlaceText())
-                , PurchaserId.of(null), Town.of(dto.getTownId(), dto.getAddress()),
+                ,  Town.of(dto.getTownId(), dto.getAddress()),
                 Collections.emptyList()
         );
 

--- a/src/main/java/com/gaaji/useditem/controller/Sample.java
+++ b/src/main/java/com/gaaji/useditem/controller/Sample.java
@@ -1,5 +1,0 @@
-package com.gaaji.useditem.controller;
-
-public class Sample {
-
-}

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -57,10 +57,10 @@ public class UsedItemPost {
 
     public static UsedItemPost of(UsedItemPostId postId, SellerId sellerId, Post post,
     Price price, boolean canSuggest, WishPlace wishPlace,
-            PurchaserId purchaserId, Town town, List<UsedItemPicture> pictures){
+             Town town, List<UsedItemPicture> pictures){
         return new UsedItemPost(postId,sellerId,post,price
                 ,canSuggest,wishPlace
-                ,TradeStatus.SELLING,purchaserId
+                ,TradeStatus.SELLING,PurchaserId.of(null)
                 ,town,pictures);
     }
     // 글 내용이 바뀐다.

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostRepositoryJpaTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostRepositoryJpaTest.java
@@ -24,7 +24,7 @@ class UsedItemPostRepositoryJpaTest {
                 UsedItemPostId.of("foo"),
                 SellerId.of("bar")
                 , Post.of("title", "contents", "category"), Price.of(1000L)
-                ,true, null, null, Town.of("townID", "address")
+                ,true, null,  Town.of("townID", "address")
                 , Collections.emptyList()
         );
 

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
@@ -30,7 +30,7 @@ class UsedItemPostTest {
 
         //when
         UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest, wishPlace,
-                purchaserId, town,
+                 town,
                 Collections.emptyList());
 
         //then


### PR DESCRIPTION
- 구매자 ID 삭제

구매자 아이디는 글 생성될 때 들어갈 필요가 없으니 팩토리 메서드 파라미터에서 지우고, 대신 값을 채워넣어줌.

```java
    public static UsedItemPost of(UsedItemPostId postId, SellerId sellerId, Post post,
    Price price, boolean canSuggest, WishPlace wishPlace,
             Town town, List<UsedItemPicture> pictures){
        return new UsedItemPost(postId,sellerId,post,price
                ,canSuggest,wishPlace
                ,TradeStatus.SELLING,PurchaserId.of(null)
                ,town,pictures);
    }

```