### PR TITLE
GM-105 중고거래 게시글 생성 시 카운터 클래스도 같이 생성

### DIFF
--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
@@ -1,14 +1,17 @@
 package com.gaaji.useditem.applicationservice;
 
 import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.domain.Counter;
 import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.Price;
 import com.gaaji.useditem.domain.PurchaserId;
 import com.gaaji.useditem.domain.SellerId;
 import com.gaaji.useditem.domain.Town;
 import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostCounter;
 import com.gaaji.useditem.domain.UsedItemPostId;
 import com.gaaji.useditem.domain.WishPlace;
+import com.gaaji.useditem.repository.UsedItemPostCounterRepository;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UsedItemPostCreateService {
 
     private final UsedItemPostRepository usedItemPostRepository;
+    private final UsedItemPostCounterRepository usedItemPostCounterRepository;
 
     public String createUsedItemPost(PostCreateRequest dto) {
 
@@ -34,6 +38,9 @@ public class UsedItemPostCreateService {
         );
 
         usedItemPostRepository.save(usedItemPost);
+        usedItemPostCounterRepository.save(UsedItemPostCounter.of(
+                UsedItemPostId.of(usedItemPost.getUsedItemPostId()),
+                Counter.of()));
 
         return usedItemPost.getUsedItemPostId();
     }

--- a/src/main/java/com/gaaji/useditem/domain/Counter.java
+++ b/src/main/java/com/gaaji/useditem/domain/Counter.java
@@ -1,9 +1,8 @@
 package com.gaaji.useditem.domain;
 
-import javax.persistence.Column;
+import java.util.Objects;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,5 +20,23 @@ public class Counter {
     }
     public void increaseViewCount(){
         viewCount++;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Counter counter = (Counter) o;
+        return suggestCount == counter.suggestCount && interestCount == counter.interestCount
+                && viewCount == counter.viewCount && chatCount == counter.chatCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(suggestCount, interestCount, viewCount, chatCount);
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPostCounter.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPostCounter.java
@@ -1,5 +1,6 @@
 package com.gaaji.useditem.domain;
 
+import java.util.Objects;
 import javax.persistence.Embedded;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -23,8 +24,28 @@ public class UsedItemPostCounter {
         return new UsedItemPostCounter(usedItemPostId,counter);
     }
 
+    public String getUsedItemPostId() {
+        return usedItemPostId.getId();
+    }
     public void increaseViewCount(){
         counter.increaseViewCount();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UsedItemPostCounter that = (UsedItemPostCounter) o;
+        return Objects.equals(usedItemPostId, that.usedItemPostId)
+                && Objects.equals(counter, that.counter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(usedItemPostId, counter);
+    }
 }

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostCounterRepository.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostCounterRepository.java
@@ -1,5 +1,12 @@
 package com.gaaji.useditem.repository;
 
+import com.gaaji.useditem.domain.UsedItemPostCounter;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import java.util.Optional;
+
 public interface UsedItemPostCounterRepository {
 
+    void save(UsedItemPostCounter usedItemPostCounter);
+
+    Optional<UsedItemPostCounter> findByPostId(UsedItemPostId postId);
 }

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostCounterRepositoryImpl.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostCounterRepositoryImpl.java
@@ -1,5 +1,8 @@
 package com.gaaji.useditem.repository;
 
+import com.gaaji.useditem.domain.UsedItemPostCounter;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,15 @@ public class UsedItemPostCounterRepositoryImpl implements
         UsedItemPostCounterRepository {
 
     private final JpaUsedItemPostCounterRepository jpaUsedItemPostCounterRepository;
+
+    @Override
+    public void save(UsedItemPostCounter usedItemPostCounter) {
+        jpaUsedItemPostCounterRepository.save(usedItemPostCounter);
+
+    }
+
+    @Override
+    public Optional<UsedItemPostCounter> findByPostId(UsedItemPostId postId) {
+        return jpaUsedItemPostCounterRepository.findById(postId);
+    }
 }

--- a/src/test/java/com/gaaji/useditem/domain/FakeUsedItemPostCounterRepository.java
+++ b/src/test/java/com/gaaji/useditem/domain/FakeUsedItemPostCounterRepository.java
@@ -1,0 +1,21 @@
+package com.gaaji.useditem.domain;
+
+import com.gaaji.useditem.repository.UsedItemPostCounterRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeUsedItemPostCounterRepository implements UsedItemPostCounterRepository {
+
+    private Map<UsedItemPostId, UsedItemPostCounter> storage = new HashMap<>();
+
+    @Override
+    public void save(UsedItemPostCounter usedItemPostCounter) {
+        storage.put(UsedItemPostId.of(usedItemPostCounter.getUsedItemPostId()), usedItemPostCounter);
+    }
+
+    @Override
+    public Optional<UsedItemPostCounter> findByPostId(UsedItemPostId postId) {
+        return Optional.ofNullable(storage.get(postId));
+    }
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCounterRepositoryJpaTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCounterRepositoryJpaTest.java
@@ -1,0 +1,34 @@
+package com.gaaji.useditem.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gaaji.useditem.repository.JpaUsedItemPostCounterRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class UsedItemPostCounterRepositoryJpaTest {
+
+    @Autowired
+    JpaUsedItemPostCounterRepository jpaUsedItemPostCounterRepository;
+    
+    
+    @Test
+    void 저장_조회 () throws Exception{
+        //given
+        String expected = "foo";
+        UsedItemPostCounter save = jpaUsedItemPostCounterRepository.save(
+                UsedItemPostCounter.of(UsedItemPostId.of(expected), Counter.of()));
+        //when
+        UsedItemPostCounter finded = jpaUsedItemPostCounterRepository.findById(
+                        UsedItemPostId.of(expected))
+                .orElseThrow();
+
+        //then
+        assertThat(finded.getUsedItemPostId()).isEqualTo(expected);
+        assertThat(save).isEqualTo(finded);
+        
+    
+    }
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
@@ -10,37 +10,48 @@ import com.gaaji.useditem.exception.InputNullDataOnPriceException;
 import com.gaaji.useditem.exception.InputNullDataOnSellerIdException;
 import com.gaaji.useditem.exception.InputNullDataOnTitleException;
 import com.gaaji.useditem.exception.InputNullDataOnTownIdException;
+import com.gaaji.useditem.repository.UsedItemPostCounterRepository;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 
 import org.junit.jupiter.api.Test;
 
 class UsedItemPostCreateServiceTest {
 
+
     @Test
     void 정상_생성 () throws Exception{
         //given
 
         PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-        ,"foo","bar","foobar");
+                ,"foo","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
 
         //when
         String postId = service.createUsedItemPost(dto);
         UsedItemPost usedItemPost = usedItemPostRepository.findByPostId(UsedItemPostId.of(postId))
                 .orElseThrow();
+
+        UsedItemPostCounter usedItemPostCounter = usedItemPostCounterRepository.findByPostId(UsedItemPostId.of(postId))
+                .orElseThrow();
+
         //then
         assertThat(usedItemPost).isNotNull();
+        assertThat(usedItemPostCounter).isNotNull();
         assertThat(usedItemPost.getUsedItemPostId()).isEqualTo(postId);
+        assertThat(usedItemPostCounter.getUsedItemPostId()).isEqualTo(postId);
     }
+
     @Test
     void 예외_제목X () throws Exception{
         PostCreateRequest dto = new PostCreateRequest("","contents","category",true,1000L, null,null,null
                 ,"foo","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
 
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
@@ -52,7 +63,8 @@ class UsedItemPostCreateServiceTest {
                 ,"foo","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
 
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
@@ -66,7 +78,8 @@ class UsedItemPostCreateServiceTest {
                 ,"foo","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
 
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
@@ -79,7 +92,8 @@ class UsedItemPostCreateServiceTest {
                 ,"foo","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
 
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
@@ -94,7 +108,8 @@ class UsedItemPostCreateServiceTest {
                 ,"","bar","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
                 .isInstanceOf(InputNullDataOnSellerIdException.class);
@@ -105,7 +120,8 @@ class UsedItemPostCreateServiceTest {
                 ,"foo","","foobar");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
                 .isInstanceOf(InputNullDataOnTownIdException.class);
@@ -116,7 +132,8 @@ class UsedItemPostCreateServiceTest {
                 ,"foo","bar","");
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository);
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
         //when // then
         assertThatThrownBy(() -> service.createUsedItemPost(dto))
                 .isInstanceOf(InputNullDataOnAddressException.class);


### PR DESCRIPTION
중고거래 게시글이 생성 될 때 카운터 클래스를 같이 생성함.


SERVICE CODE

```java
class UsedItemPostCreateService{
 public String createUsedItemPost(PostCreateRequest dto) {

//       (....)
        usedItemPostRepository.save(usedItemPost);
        usedItemPostCounterRepository.save(UsedItemPostCounter.of(
                UsedItemPostId.of(usedItemPost.getUsedItemPostId()),
                Counter.of()));

        return usedItemPost.getUsedItemPostId();
    }
}
```


#### DB 결과
![image](https://user-images.githubusercontent.com/76154390/213091527-8535a058-cd84-48e5-970b-90bf446fea46.png)


#### 고민
현재 서비스가 하나의 역할을 담당하는데, 카운터 객체를 생성하는 다른 서비스를 받고 위임을 하도록 해야 할지??

```java
class UsedItemPostCreateService{
 public String createUsedItemPost(PostCreateRequest dto) {

//       (....)
        usedItemPostRepository.save(usedItemPost);
       usedItemPostCounterCreateService.createCounter(postId);
 
        return usedItemPost.getUsedItemPostId();
    }
}
```