### PR TITLE
GM-113 동네 정보 토큰을 통해 중고거래 글 쓰기 기능 강화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,12 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     implementation 'org.springframework.kafka:spring-kafka'
 
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/gaaji/useditem/UseditemApplication.java
+++ b/src/main/java/com/gaaji/useditem/UseditemApplication.java
@@ -2,7 +2,10 @@ package com.gaaji.useditem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+
+@EnableFeignClients
 @SpringBootApplication
 public class UseditemApplication {
 

--- a/src/main/java/com/gaaji/useditem/adaptor/TownAddressResponse.java
+++ b/src/main/java/com/gaaji/useditem/adaptor/TownAddressResponse.java
@@ -1,0 +1,16 @@
+package com.gaaji.useditem.adaptor;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE) @NoArgsConstructor
+public class TownAddressResponse {
+    private String address;
+
+    public static TownAddressResponse of(String address){
+        return new TownAddressResponse(address);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/adaptor/TownServiceClient.java
+++ b/src/main/java/com/gaaji/useditem/adaptor/TownServiceClient.java
@@ -1,0 +1,12 @@
+package com.gaaji.useditem.adaptor;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient("town-service")
+public interface TownServiceClient {
+
+    @GetMapping("/town/{townId}")
+    TownAddressResponse retrieveTownAddress(@PathVariable("townId") String townId);
+}

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostCreateService.java
@@ -1,6 +1,10 @@
 package com.gaaji.useditem.applicationservice;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.useditem.adaptor.TownServiceClient;
 import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.controller.dto.TownToken;
 import com.gaaji.useditem.domain.Counter;
 import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.Price;
@@ -10,6 +14,8 @@ import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostCounter;
 import com.gaaji.useditem.domain.UsedItemPostId;
 import com.gaaji.useditem.domain.WishPlace;
+import com.gaaji.useditem.exception.JsonParsingException;
+import com.gaaji.useditem.exception.TownUnAuthentiactedException;
 import com.gaaji.useditem.repository.UsedItemPostCounterRepository;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,22 +29,45 @@ public class UsedItemPostCreateService {
 
     private final UsedItemPostRepository usedItemPostRepository;
     private final UsedItemPostCounterRepository usedItemPostCounterRepository;
+    private final TownServiceClient townServiceClient;
 
-    public String createUsedItemPost(PostCreateRequest dto) {
+    public String createUsedItemPost(PostCreateRequest dto, String authorization, String townToken) {
+        try {
+            return saveEntity(createUsedItemPostEntity(dto, authorization, parseTownToken(townToken)));
+        } catch (JsonProcessingException e) {
+            throw new JsonParsingException();
+        }
+    }
 
-        UsedItemPost usedItemPost = UsedItemPost.of(UsedItemPostId.of(usedItemPostRepository.nextId())
-                , SellerId.of(dto.getAuthId()),
-                Post.of(dto.getTitle(), dto.getContents(), dto.getCategory())
-                , Price.of(dto.getPrice()), dto.getCanSuggest(),
-                WishPlace.of(dto.getPlaceX(), dto.getPlaceY(), dto.getPlaceText())
-                ,  Town.of(dto.getTownId(), dto.getAddress())
-        );
-
+    private String saveEntity(UsedItemPost usedItemPost) {
         usedItemPostRepository.save(usedItemPost);
         usedItemPostCounterRepository.save(UsedItemPostCounter.of(
                 UsedItemPostId.of(usedItemPost.getUsedItemPostId()),
                 Counter.of()));
-
         return usedItemPost.getUsedItemPostId();
+    }
+
+    private TownToken parseTownToken(String townToken) throws JsonProcessingException {
+        TownToken token = new ObjectMapper().readValue(townToken, TownToken.class);
+        if(!token.isAuthenticated())
+            throw new TownUnAuthentiactedException();
+        return token;
+    }
+
+    private UsedItemPost createUsedItemPostEntity(PostCreateRequest dto, String authorization,
+            TownToken token) {
+        // TODO refactor factory method
+        return UsedItemPost.of(UsedItemPostId.of(usedItemPostRepository.nextId())
+                , SellerId.of(authorization),
+                Post.of(dto.getTitle(), dto.getContents(), dto.getCategory())
+                , Price.of(dto.getPrice()), dto.getCanSuggest(),
+                WishPlace.of(dto.getPlaceX(), dto.getPlaceY(), dto.getPlaceText())
+                ,  Town.of(token.getTownId(),  getAddressFromTownService(token))
+        );
+    }
+
+    private String getAddressFromTownService(TownToken token) {
+        return townServiceClient.retrieveTownAddress(
+                token.getTownId()).getAddress();
     }
 }

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostCreateController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostCreateController.java
@@ -4,6 +4,7 @@ import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
 import com.gaaji.useditem.controller.dto.PostCreateRequest;
 import com.gaaji.useditem.controller.dto.PostCreateResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class UsedItemPostCreateController {
@@ -19,13 +21,12 @@ public class UsedItemPostCreateController {
     private final UsedItemPostCreateService usedItemPostCreateService;
 
     @PostMapping("/posts")
-    public ResponseEntity<PostCreateResponse> createUsedItemPost(@RequestHeader(HttpHeaders.AUTHORIZATION)
-    String authorization,
-            @RequestHeader("X-TOWN-TOKEN") String townToken
-            , @RequestBody PostCreateRequest dto
+    public ResponseEntity<PostCreateResponse> createUsedItemPost(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+            @RequestHeader("X-TOWN-TOKEN") String townToken,
+            @RequestBody PostCreateRequest dto
     ) {
-        dto.injectHeaderInfo(authorization,townToken);
-        String postId = usedItemPostCreateService.createUsedItemPost(dto);
+        String postId = usedItemPostCreateService.createUsedItemPost(dto,  authorization, townToken);
         return ResponseEntity.status(HttpStatus.CREATED).body(new PostCreateResponse(postId));
     }
 

--- a/src/main/java/com/gaaji/useditem/controller/dto/PostCreateRequest.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostCreateRequest.java
@@ -19,20 +19,4 @@ public class PostCreateRequest {
     private String placeX;
     private String placeY;
     private String placeText;
-
-    private String authId;
-    private String townId;
-    private String address;
-
-    public void injectHeaderInfo(String authId, String townHeader){
-        this.authId = authId;
-        TownToken townToken = null;
-        try {
-             townToken = new ObjectMapper().readValue(townHeader, TownToken.class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-        this.townId = townToken.getTownId();
-        this.address = townToken.getAddress();
-    }
 }

--- a/src/main/java/com/gaaji/useditem/controller/dto/Sample.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/Sample.java
@@ -1,5 +1,0 @@
-package com.gaaji.useditem.controller.dto;
-
-public class Sample {
-
-}

--- a/src/main/java/com/gaaji/useditem/controller/dto/TownToken.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/TownToken.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 public class TownToken {
     private String townId;
-    private String address;
+
+    private boolean isAuthenticated;
 
 }

--- a/src/main/java/com/gaaji/useditem/exception/JsonParsingException.java
+++ b/src/main/java/com/gaaji/useditem/exception/JsonParsingException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.JSON_PARSING_ERROR;
+
+public class JsonParsingException extends AbstractApiException{
+
+    public JsonParsingException() {
+        super(JSON_PARSING_ERROR);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/TownUnAuthentiactedException.java
+++ b/src/main/java/com/gaaji/useditem/exception/TownUnAuthentiactedException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.TOWN_UNAUTHENTICATED;
+
+public class TownUnAuthentiactedException extends AbstractApiException{
+
+    public TownUnAuthentiactedException() {
+        super(TOWN_UNAUTHENTICATED);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
+++ b/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
@@ -33,7 +33,10 @@ public enum UsedItemErrorCode implements ErrorCode {
     		"해당하는 중고거래글을 찾지 못했습니다."),
     No_Match_Auth_Id_And_Seller_Id(HttpStatus.UNAUTHORIZED, "u-0009",
     		"유저 정보(Id)가 작성자 정보(Id)와 일치하지 않습니다."),
-	
+    TOWN_UNAUTHENTICATED(HttpStatus.FORBIDDEN, "u-0010",
+            "동네가 인증되지 않았습니다."),
+    JSON_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "u-0011",
+            "JSON 파싱 과정에서 오류가 발생"),
     ;
 	
 	private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,12 @@ spring:
     defer-datasource-initialization: true
   config:
     import: secret.yml
+  application:
+    name: used-item-service
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone : http://localhost:8761/eureka

--- a/src/test/java/com/gaaji/useditem/domain/StubNullTownServiceClient.java
+++ b/src/test/java/com/gaaji/useditem/domain/StubNullTownServiceClient.java
@@ -1,0 +1,12 @@
+package com.gaaji.useditem.domain;
+
+import com.gaaji.useditem.adaptor.TownAddressResponse;
+import com.gaaji.useditem.adaptor.TownServiceClient;
+
+public class StubNullTownServiceClient implements TownServiceClient {
+
+    @Override
+    public TownAddressResponse retrieveTownAddress(String townId) {
+        return TownAddressResponse.of("");
+    }
+}

--- a/src/test/java/com/gaaji/useditem/domain/StubTownServiceClient.java
+++ b/src/test/java/com/gaaji/useditem/domain/StubTownServiceClient.java
@@ -1,0 +1,12 @@
+package com.gaaji.useditem.domain;
+
+import com.gaaji.useditem.adaptor.TownAddressResponse;
+import com.gaaji.useditem.adaptor.TownServiceClient;
+
+public class StubTownServiceClient implements TownServiceClient {
+
+    @Override
+    public TownAddressResponse retrieveTownAddress(String townId) {
+        return TownAddressResponse.of("foo");
+    }
+}

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateControllerTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateControllerTest.java
@@ -2,19 +2,18 @@ package com.gaaji.useditem.domain;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
 import com.gaaji.useditem.controller.UsedItemPostCreateController;
 import com.gaaji.useditem.controller.dto.PostCreateRequest;
 import com.gaaji.useditem.controller.dto.TownToken;
-import com.sun.xml.bind.v2.TODO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -45,11 +44,11 @@ class UsedItemPostCreateControllerTest {
     void 정상생성 () throws Exception{
         //given
         BDDMockito.given(usedItemPostCreateService
-                .createUsedItemPost(ArgumentMatchers.any()))
+                .createUsedItemPost(ArgumentMatchers.any(), anyString(), anyString()))
                 .willReturn("foo");
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-                ,"foo","bar","foobar");
-        TownToken townToken = new TownToken("foo","bar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
+
+        TownToken townToken = new TownToken("foo",true);
 
 
         //when

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostCreateServiceTest.java
@@ -2,14 +2,19 @@ package com.gaaji.useditem.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.useditem.adaptor.TownServiceClient;
 import com.gaaji.useditem.applicationservice.UsedItemPostCreateService;
 import com.gaaji.useditem.controller.dto.PostCreateRequest;
+import com.gaaji.useditem.controller.dto.TownToken;
 import com.gaaji.useditem.exception.InputNullDataOnAddressException;
 import com.gaaji.useditem.exception.InputNullDataOnCategoryException;
 import com.gaaji.useditem.exception.InputNullDataOnPriceException;
 import com.gaaji.useditem.exception.InputNullDataOnSellerIdException;
 import com.gaaji.useditem.exception.InputNullDataOnTitleException;
 import com.gaaji.useditem.exception.InputNullDataOnTownIdException;
+import com.gaaji.useditem.exception.JsonParsingException;
+import com.gaaji.useditem.exception.TownUnAuthentiactedException;
 import com.gaaji.useditem.repository.UsedItemPostCounterRepository;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 
@@ -22,15 +27,15 @@ class UsedItemPostCreateServiceTest {
     void 정상_생성 () throws Exception{
         //given
 
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-                ,"foo","bar","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
-
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
         //when
-        String postId = service.createUsedItemPost(dto);
+        String postId = service.createUsedItemPost(dto, "foo",  new ObjectMapper().writeValueAsString(townToken));
         UsedItemPost usedItemPost = usedItemPostRepository.findByPostId(UsedItemPostId.of(postId))
                 .orElseThrow();
 
@@ -45,58 +50,95 @@ class UsedItemPostCreateServiceTest {
     }
 
     @Test
-    void 예외_제목X () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("","contents","category",true,1000L, null,null,null
-                ,"foo","bar","foobar");
+    void 예외_인증X () throws Exception{
+        //given
+
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",false);
+        //when
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo",  new ObjectMapper().writeValueAsString(townToken)))
+                .isInstanceOf(TownUnAuthentiactedException.class);
 
+    }
+
+    @Test
+    void 예외_파싱에러X () throws Exception{
+        //given
+
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+
+        //when
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo",  "bar"))
+                .isInstanceOf(JsonParsingException.class);
+
+    }
+
+
+
+    @Test
+    void 예외_제목X () throws Exception{
+        PostCreateRequest dto = new PostCreateRequest("","contents","category",true,1000L, null,null,null);
+
+        UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
+        UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo",  new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnTitleException.class);
     }
     @Test
     void 예외_카테고리X () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("title","contents","",true,1000L, null,null,null
-                ,"foo","bar","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
 
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo",   new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnCategoryException.class);
     
     }
     
     @Test
     void 예외_가격X () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,null, null,null,null
-                ,"foo","bar","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,null, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
-
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo",   new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnPriceException.class);
     }
 
     @Test
     void 예외_가격_음수 () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,-2000L, null,null,null
-                ,"foo","bar","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,-2000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
-
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto,"foo", new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnPriceException.class);
     }
 
@@ -104,38 +146,44 @@ class UsedItemPostCreateServiceTest {
     @Test
     void 예외_판매자ID () throws Exception{
         //given
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-                ,"","bar","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken("foo",true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "", new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnSellerIdException.class);
     }
     @Test
     void 예외_동네ID () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-                ,"foo","","foobar");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
+        TownServiceClient townServiceClient = new StubTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken();
+        townToken.setAuthenticated(true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto, "foo", new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnTownIdException.class);
     }
     @Test
     void 예외_동네주소 () throws Exception{
-        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null
-                ,"foo","bar","");
+        PostCreateRequest dto = new PostCreateRequest("title","contents","category",true,1000L, null,null,null);
 
         UsedItemPostRepository usedItemPostRepository = new FakeUsedItemPostRepository();
         UsedItemPostCounterRepository usedItemPostCounterRepository = new FakeUsedItemPostCounterRepository();
-        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository);
+        TownServiceClient townServiceClient = new StubNullTownServiceClient();
+        UsedItemPostCreateService service = new UsedItemPostCreateService(usedItemPostRepository, usedItemPostCounterRepository,townServiceClient);
+        TownToken townToken = new TownToken();
+        townToken.setTownId("foo");
+        townToken.setAuthenticated(true);
         //when // then
-        assertThatThrownBy(() -> service.createUsedItemPost(dto))
+        assertThatThrownBy(() -> service.createUsedItemPost(dto,"foo", new ObjectMapper().writeValueAsString(townToken)))
                 .isInstanceOf(InputNullDataOnAddressException.class);
     }
 


### PR DESCRIPTION
### 개요
동네 정보 토큰(토큰ID, 인증 상태)를 통해 글쓰기 기능을 강화했다.
1. 인증 상태를 검증하여, 인증되지 않을 경우 예외 발생
2. 토큰ID를 통해 동네 서비스에 address를 조회해 가져온다.

### 서비스간 동기 통신 FeignClient

#### 의존성 추가
build.gradle
![image](https://user-images.githubusercontent.com/76154390/213634944-598fbf4a-5c30-41f4-ba0d-fedec3a0714e.png)

#### 사용 방법
1. 메인 어플리케이션에 @EnableFeignClient 작성
```java
@EnableFeignClients
@SpringBootApplication
public class UseditemApplication {
    public static void main(String[] args) {
        SpringApplication.run(UseditemApplication.class, args);
    }
}
```
2. FeignClient 관련 인터페이스 작성
```java
@FeignClient("town-service") <- 통신할 서비스의 spring.application.name
public interface TownServiceClient {

    @GetMapping("/town/{townId}") <- 통신할 서비스의 api (컨트롤러와 같게 작성)
    TownAddressResponse retrieveTownAddress(@PathVariable("townId") String townId);
}

```

### 결과
![image](https://user-images.githubusercontent.com/76154390/213635428-0e7a86a5-cb7d-42df-9c57-b6dfaf0b0598.png)



### 참고자료
https://wildeveloperetrain.tistory.com/172
https://velog.io/@haron/Feign-client-%EC%A0%81%EC%9A%A9%EA%B8%B0

