### PR TITLE
GM-158 이미지 추가 & 수정 시 대표 URL 설정

### DIFF
--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -108,6 +108,7 @@ public class UsedItemPost {
                     changedPictures.add(picture);
         this.pictures.clear();
         this.pictures.addAll(changedPictures);
+        setRepresentPictureUrl();
     }
 
     public void reverseHide(){
@@ -150,17 +151,28 @@ public class UsedItemPost {
 
     public void addPictures(List<UsedItemPicture> list) {
         list.forEach((p) -> p.associateWithPost(this));
+
         this.pictures.clear();
         this.pictures.addAll(list);
+        setRepresentPictureUrl();
 
     }
+
+    private void setRepresentPictureUrl() {
+        if (pictures.isEmpty()) {
+            this.representPictureUrl = null;
+            return;
+        }
+        this.representPictureUrl = pictures.get(0).getUrl();
+    }
+
     public void addPictures(List<UsedItemPicture> newPictures, int[] indexes) {
         newPictures.forEach((p) -> p.associateWithPost(this));
         int i = 0;
         for (int index : indexes) {
             this.pictures.add(index, newPictures.get(i++));
         }
-
+        setRepresentPictureUrl();
     }
 
     public String getTitle() {
@@ -215,6 +227,10 @@ public class UsedItemPost {
 
     public String getSellerId() {
         return this.sellerId.getId();
+    }
+
+    public String getRepresentPictureUrl(){
+        return this.representPictureUrl;
     }
 
 

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
@@ -8,6 +8,7 @@ import com.gaaji.useditem.exception.ReservationStatusChangePriceException;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -275,6 +276,86 @@ class UsedItemPostModifyTest {
 
         //then
         assertThat(usedItemPost.getRepresentPictureUrl()).isEqualTo("url10");
+    }
+    @Test
+    void 정상_사진이_전부_삭제될_경우_대표URL이_null() throws Exception {
+        //given
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        Town town = Town.of("foo", "bar");
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest,
+                wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> pictures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pictures.add(UsedItemPicture.of(UsedItemPictureId.of(UUID.randomUUID().toString()),
+                    "url" + i));
+        }
+        usedItemPost.addPictures(pictures);
+
+        String title = "title";
+        String content = "content";
+        String category = "category";
+        int updatedPrice = 10000;
+        boolean updatedHide = true;
+        boolean updatedSuggest = true;
+        PostUpdateRequest dto = new PostUpdateRequest(title, content, category, updatedPrice,
+                updatedHide, updatedSuggest, "", "", "", Collections.EMPTY_LIST);
+        //when
+        usedItemPost.modify(sellerId, dto);
+
+
+        //then
+        assertThat(usedItemPost.getRepresentPictureUrl()).isNull();
+    }
+
+    @Test
+    void 정상_사진의_순서가_바뀔_경우_대표_URL이_바뀐다() throws Exception {
+        //given
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        Town town = Town.of("foo", "bar");
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest,
+                wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> pictures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pictures.add(UsedItemPicture.of(UsedItemPictureId.of(UUID.randomUUID().toString()),
+                    "url" + i));
+        }
+        usedItemPost.addPictures(pictures);
+
+        List<String> urls = new ArrayList<>();
+        urls.add("url1");
+        urls.add("url0");
+        urls.add("url2");
+        String title = "title";
+        String content = "content";
+        String category = "category";
+        int updatedPrice = 10000;
+        boolean updatedHide = true;
+        boolean updatedSuggest = true;
+        PostUpdateRequest dto = new PostUpdateRequest(title, content, category, updatedPrice,
+                updatedHide, updatedSuggest, "", "", "", urls);
+
+        String authorization = "seller";
+
+        //when
+        usedItemPost.modify(SellerId.of(authorization), dto);
+        //then
+        assertThat(usedItemPost.getRepresentPictureUrl()).isEqualTo("url1");
     }
 
     @Test

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
@@ -239,7 +239,42 @@ class UsedItemPostModifyTest {
         assertThat(picturesUrl.get(2)).isEqualTo("url1");
         assertThat(picturesUrl.get(3)).isEqualTo("url11");
         assertThat(picturesUrl.get(4)).isEqualTo("url2");
+    }
 
+    @Test
+    void 정상_새로운_사진이_대표_URL로_설정됨() throws Exception {
+        //given
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        Town town = Town.of("foo", "bar");
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest,
+                wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> pictures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pictures.add(UsedItemPicture.of(UsedItemPictureId.of(UUID.randomUUID().toString()),
+                    "url" + i));
+        }
+        usedItemPost.addPictures(pictures);
+
+        List<UsedItemPicture> newPictures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            newPictures.add(UsedItemPicture.of(UsedItemPictureId.of(UUID.randomUUID().toString()),
+                    "url1" + i));
+        }
+        int[] index = new int[]{0, 3};
+        //when
+
+        usedItemPost.addPictures(newPictures, index);
+
+        //then
+        assertThat(usedItemPost.getRepresentPictureUrl()).isEqualTo("url10");
     }
 
     @Test

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
@@ -67,6 +67,33 @@ class UsedItemPostTest {
 
         //then
         assertThat( ((List<UsedItemPicture>)pictures.get(usedItemPost)).size()).isSameAs(5);
+    }
+
+    @Test
+    void 사진_업로드_대표_URL_체크 () throws Exception{
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        PurchaserId purchaserId = PurchaserId.of(null);
+        Town town = Town.of("foo", "bar");
+
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest, wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> list = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            list.add(UsedItemPicture.of(UsedItemPictureId.of("foo" + i), "url" + i));
+        }
+
+        //when
+        usedItemPost.addPictures(list);
+
+        assertThat(usedItemPost.getRepresentPictureUrl())
+                .isEqualTo("url0");
 
 
     }


### PR DESCRIPTION
# GM-158 이미지 추가 & 수정 시 대표 URL 설정
## Description
> 중고거래 글 리스트 조회 시 사용되는 대표 URL을 설정하는 기능

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-89 중고거래 글 목록 조회
- GM-85 내 판매목록 조회

## Issues
중고거래 글의 대표 URL을 설정해준다. 
이에는 다음과 같은 케이스가 존재한다.
1. 처음 이미지를 추가하는 경우
2. 대표 이미지가 변경되는 경우
3. 이미지들이 전부 삭제되는 경우

#### 1번 케이스
처음 이미지가 추가되면 대표 이미지인 0번 이미지의 URL을 대표 URL로 설정해준다.
아래 사진은 글을 추가한 후 이미지를 추가하면 대표 URL이 설정되는 것을 볼 수 있다.
![image](https://user-images.githubusercontent.com/76154390/215416716-dd5f3f05-3eef-4e9e-b2e5-6b3f7839392e.png)

#### 2번 케이스
중고거래 글 수정을 통해 이미지의 순서가 바뀌거나, 이미지 추가 업로드를 통해 대표 이미지가 변경되는 경우 대표 URL이 변경된다.
아래 이미지는 각각 추가 이미지 업로드와 글 수정을 통해 순서가 변경되는 케이스이다.
![image](https://user-images.githubusercontent.com/76154390/215417057-48bc633b-2cd3-46e1-96ec-56f2db70860a.png)
![image](https://user-images.githubusercontent.com/76154390/215417158-c3ba19ab-af01-4c1e-813a-656dfa9fb9c8.png)

#### 3번 케이스
중고거래 글 수정을 통해 모든 이미지들이 삭제되는 경우 대표 URL을 null로 초기화한다.
![image](https://user-images.githubusercontent.com/76154390/215417427-88cb51cb-b406-4ffe-99e2-6f3095009e50.png)



### Test
  
![image](https://user-images.githubusercontent.com/76154390/215418616-b6b61084-635f-4b5d-bd61-7d6a18ba510a.png)

*** 

## Related Files
- `UsedItemPost`

## Think About..  
사진 Order쪽 관련해서 추가된다면, 위 부분에 수정이 발생할 것이다. 
## Conclusion  
> 테스트 케이스를 다 생각 안하고 있다가 다시 추가하는 경우가 있었는데, 미리미리 생각을 다 하고 코드를 짜야 할 것 같다.
