### PR TITLE
GM-159 UsedItemPicture에 Order 필드 생성하여 글 조회할 때 순서에 맞게 조회하도록 설정

### DIFF
--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPicture.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPicture.java
@@ -1,6 +1,7 @@
 package com.gaaji.useditem.domain;
 
 import java.util.Objects;
+import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class UsedItemPicture {
+public class UsedItemPicture implements Comparable<UsedItemPicture>{
 
     @EmbeddedId
     private UsedItemPictureId pictureId;
@@ -23,20 +24,28 @@ public class UsedItemPicture {
     private UsedItemPost post;
 
     private String url;
+    @Column(name = "picture_order")
+    private Integer order;
 
 
     public static UsedItemPicture of(UsedItemPictureId pictureId,
             String url){
-        return new UsedItemPicture(pictureId,null,url);
+        return new UsedItemPicture(pictureId,null,url,null);
     }
 
     public String getUsedItemPictureId() {
         return pictureId.getId();
     }
 
-    public void associateWithPost(UsedItemPost usedItemPost) {
+    public void associateWithPost(UsedItemPost usedItemPost, Integer order) {
         this.post = usedItemPost;
+        this.order = order;
     }
+
+    public void changeOrder(Integer order){
+        this.order = order;
+    }
+
 
     public String getUrl() {
         return url;
@@ -57,5 +66,14 @@ public class UsedItemPicture {
     @Override
     public int hashCode() {
         return Objects.hash(url);
+    }
+
+    @Override
+    public int compareTo(UsedItemPicture o) {
+        return this.order.compareTo(o.getOrder());
+    }
+
+    private Integer getOrder() {
+        return order;
     }
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -5,6 +5,8 @@ import com.gaaji.useditem.exception.NoMatchAuthIdAndSellerIdException;
 import com.gaaji.useditem.exception.ReservationStatusChangePriceException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.AttributeOverride;
@@ -108,6 +110,7 @@ public class UsedItemPost {
                     changedPictures.add(picture);
         this.pictures.clear();
         this.pictures.addAll(changedPictures);
+        pictures.forEach(p -> p.changeOrder(pictures.indexOf(p)));
         setRepresentPictureUrl();
     }
 
@@ -150,12 +153,10 @@ public class UsedItemPost {
 	}
 
     public void addPictures(List<UsedItemPicture> list) {
-        list.forEach((p) -> p.associateWithPost(this));
-
         this.pictures.clear();
         this.pictures.addAll(list);
+        this.pictures.forEach(p -> p.associateWithPost(this, pictures.indexOf(p)));
         setRepresentPictureUrl();
-
     }
 
     private void setRepresentPictureUrl() {
@@ -167,11 +168,11 @@ public class UsedItemPost {
     }
 
     public void addPictures(List<UsedItemPicture> newPictures, int[] indexes) {
-        newPictures.forEach((p) -> p.associateWithPost(this));
         int i = 0;
         for (int index : indexes) {
             this.pictures.add(index, newPictures.get(i++));
         }
+        this.pictures.forEach(p -> p.associateWithPost(this, pictures.indexOf(p)));
         setRepresentPictureUrl();
     }
 
@@ -220,6 +221,7 @@ public class UsedItemPost {
     }
 
     public List<String> getPicturesUrl(){
+        Collections.sort(pictures);
         return this.pictures.stream().map(UsedItemPicture::getUrl)
                 .toList();
     }

--- a/src/main/java/com/gaaji/useditem/repository/JpaUsedItemPostRepository.java
+++ b/src/main/java/com/gaaji/useditem/repository/JpaUsedItemPostRepository.java
@@ -7,6 +7,7 @@ import com.gaaji.useditem.domain.UsedItemPostId;
 
 import java.util.List;
 
+import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,8 @@ public interface JpaUsedItemPostRepository extends JpaRepository<UsedItemPost, U
             + "where u.sellerId.id =:authId order by u.post.createdAt desc")
 	List<PreviewPost> findByauthId(@Param("authId") String authId);
 
+
+	@Query("select distinct p from UsedItemPost p left join fetch UsedItemPicture up on up.post = p "
+			+ "where p.postId = :postId")
+	Optional<UsedItemPost> findPostByPostId(@Param("postId") UsedItemPostId usedItemPostId);
 }

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepository.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepository.java
@@ -1,28 +1,13 @@
 package com.gaaji.useditem.repository;
 
+import com.gaaji.useditem.controller.dto.PreviewPost;
+import com.gaaji.useditem.domain.SellerId;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostId;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.data.domain.PageRequest;
-
-import java.util.Optional;
-
-import com.gaaji.useditem.controller.dto.PreviewPost;
-import com.gaaji.useditem.domain.Post;
-import com.gaaji.useditem.domain.SellerId;
-import com.gaaji.useditem.domain.UsedItemPost;
-import com.gaaji.useditem.domain.UsedItemPostId;
-
-import java.util.Optional;
-
-import com.gaaji.useditem.domain.Post;
-import com.gaaji.useditem.domain.SellerId;
-import com.gaaji.useditem.domain.UsedItemPost;
-import com.gaaji.useditem.domain.UsedItemPostId;
 
 public interface UsedItemPostRepository {
 
@@ -40,6 +25,8 @@ public interface UsedItemPostRepository {
 	List<PreviewPost> findByTownId(String townId, PageRequest pageRequest);
 
 	List<PreviewPost> findByauthId(String authId);
+
+//    Optional<UsedItemPost> findByPicture
 
 
 

--- a/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepositoryImpl.java
+++ b/src/main/java/com/gaaji/useditem/repository/UsedItemPostRepositoryImpl.java
@@ -7,16 +7,11 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Optional;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import com.gaaji.useditem.controller.dto.PreviewPost;
-import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.SellerId;
-import com.gaaji.useditem.domain.UsedItemPost;
-import com.gaaji.useditem.domain.UsedItemPostId;
 
 @RequiredArgsConstructor
 @Repository
@@ -27,7 +22,7 @@ public class UsedItemPostRepositoryImpl implements
 
     @Override
     public Optional<UsedItemPost> findByPostId(UsedItemPostId postId) {
-        return jpaUsedItemPostRepository.findById(postId);
+        return jpaUsedItemPostRepository.findPostByPostId(postId);
     }
 
     @Override

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPictureTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPictureTest.java
@@ -48,12 +48,18 @@ class UsedItemPictureTest {
         UsedItemPicture picture = UsedItemPicture.of(UsedItemPictureId.of("foo"), "url");
 
         //when
-        picture.associateWithPost(usedItemPost);
+        picture.associateWithPost(usedItemPost,0);
         Field postField = picture.getClass().getDeclaredField("post");
         postField.setAccessible(true);
+
+        Field order = picture.getClass().getDeclaredField("order");
+        order.setAccessible(true);
+
         //then
         assertThat(postField.get(picture)).isEqualTo(usedItemPost);
+        assertThat(order.get(picture)).isSameAs(0);
     }
+
     
     @Test
     void Url비교_테스트 () throws Exception{

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostModifyTest.java
@@ -359,6 +359,61 @@ class UsedItemPostModifyTest {
     }
 
     @Test
+    void 정상_사진의_순서가_바뀔_경우_각_사진의_order가_바뀐다() throws Exception {
+        //given
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        Town town = Town.of("foo", "bar");
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest,
+                wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> pictures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pictures.add(UsedItemPicture.of(UsedItemPictureId.of(UUID.randomUUID().toString()),
+                    "url" + i));
+        }
+        usedItemPost.addPictures(pictures);
+
+        List<String> urls = new ArrayList<>();
+        urls.add("url1");
+        urls.add("url0");
+        urls.add("url2");
+        String title = "title";
+        String content = "content";
+        String category = "category";
+        int updatedPrice = 10000;
+        boolean updatedHide = true;
+        boolean updatedSuggest = true;
+        PostUpdateRequest dto = new PostUpdateRequest(title, content, category, updatedPrice,
+                updatedHide, updatedSuggest, "", "", "", urls);
+
+        String authorization = "seller";
+        usedItemPost.modify(SellerId.of(authorization), dto);
+        Field fPictures = usedItemPost.getClass().getDeclaredField("pictures");
+        fPictures.setAccessible(true);
+        //when
+
+
+        List<UsedItemPicture> modified = (List<UsedItemPicture>) fPictures.get(usedItemPost);
+        //then
+
+        int o = 0;
+        for (UsedItemPicture usedItemPicture : modified) {
+            Field order = usedItemPicture.getClass().getDeclaredField("order");
+            order.setAccessible(true);
+            assertThat(order.get(usedItemPicture)).isSameAs(o++);
+        }
+
+
+    }
+
+    @Test
     void 예외_인덱스가_범위를_초과함() throws Exception {
         //given
         UsedItemPostId itemPostId = UsedItemPostId.of("foo");

--- a/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
+++ b/src/test/java/com/gaaji/useditem/domain/UsedItemPostTest.java
@@ -94,8 +94,37 @@ class UsedItemPostTest {
 
         assertThat(usedItemPost.getRepresentPictureUrl())
                 .isEqualTo("url0");
+    }
 
+    @Test
+    void 사진_Order_체크 () throws Exception{
+        UsedItemPostId itemPostId = UsedItemPostId.of("foo");
+        SellerId sellerId = SellerId.of("seller");
+        Post post = Post.of("foo", "bar", "foobar");
+        Price price = Price.of(1000L);
+        boolean canSuggest = false;
+        WishPlace wishPlace = null;
+        PurchaserId purchaserId = PurchaserId.of(null);
+        Town town = Town.of("foo", "bar");
 
+        UsedItemPost usedItemPost = UsedItemPost.of(itemPostId, sellerId, post, price, canSuggest, wishPlace,
+                town
+        );
+
+        List<UsedItemPicture> list = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            list.add(UsedItemPicture.of(UsedItemPictureId.of("foo" + i), "url" + i));
+        }
+
+        //when
+        usedItemPost.addPictures(list);
+
+        int o = 0;
+        for (UsedItemPicture usedItemPicture : list) {
+            Field order = usedItemPicture.getClass().getDeclaredField("order");
+            order.setAccessible(true);
+            assertThat(order.get(usedItemPicture)).isSameAs(o++);
+        }
     }
 
     @Test

--- a/src/test/java/com/gaaji/useditem/repository/UsedItemPostRepositoryJpaTest.java
+++ b/src/test/java/com/gaaji/useditem/repository/UsedItemPostRepositoryJpaTest.java
@@ -2,18 +2,22 @@ package com.gaaji.useditem.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.gaaji.useditem.applicationservice.UsedItemPostUpdateService;
+import com.gaaji.useditem.controller.dto.PostUpdateRequest;
 import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.Price;
 import com.gaaji.useditem.domain.SellerId;
 import com.gaaji.useditem.domain.Town;
+import com.gaaji.useditem.domain.TradeStatus;
 import com.gaaji.useditem.domain.UsedItemPicture;
 import com.gaaji.useditem.domain.UsedItemPictureId;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostId;
-import com.gaaji.useditem.repository.JpaUsedItemPostRepository;
+import com.netflix.discovery.converters.Auto;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -23,6 +27,9 @@ class UsedItemPostRepositoryJpaTest {
 
     @Autowired
     JpaUsedItemPostRepository jpaUsedItemPostRepository;
+
+    @Autowired
+    EntityManager em;
     
     
     @Test
@@ -77,6 +84,66 @@ class UsedItemPostRepositoryJpaTest {
     
     }
 
+    @Test
+    void 사진의_Order로_정렬_테스트_사진이_존재할_때 () throws Exception{
+        //given
+        List<UsedItemPicture> pictureList = new ArrayList<>();
+        pictureList.add(UsedItemPicture.of(UsedItemPictureId.of("foo1"),"url1"));
+        pictureList.add(UsedItemPicture.of(UsedItemPictureId.of("foo"),"url"));
+
+
+        UsedItemPost usedItemPost = UsedItemPost.of(
+                UsedItemPostId.of("foo"),
+                SellerId.of("bar")
+                , Post.of("title", "contents", "category"), Price.of(1000L)
+                ,true, null,  Town.of("townID", "address")
+        );
+
+        usedItemPost.addPictures(pictureList);
+        jpaUsedItemPostRepository.save(usedItemPost);
+        //when
+
+
+
+        UsedItemPost finded = jpaUsedItemPostRepository.findPostByPostId(UsedItemPostId.of("foo"))
+                .orElseThrow();
+
+
+
+        List<String> urls = new ArrayList<>();
+        urls.add("url");
+        urls.add("url1");
+        PostUpdateRequest dto = new PostUpdateRequest("title", "content", "category", 10000, false, false, "","","", urls);
+
+
+
+        finded.modify(SellerId.of("bar"), dto);
+
+        em.flush();
+        em.clear();
+
+        UsedItemPost last = jpaUsedItemPostRepository.findPostByPostId(
+                        UsedItemPostId.of("foo"))
+                .orElseThrow();
+
+        //then
+        Field fPictures = usedItemPost.getClass().getDeclaredField("pictures");
+        fPictures.setAccessible(true);
+        //when
+
+
+        List<UsedItemPicture> modified = (List<UsedItemPicture>) fPictures.get(usedItemPost);
+        //then
+
+
+
+        assertThat(modified.get(0)).isEqualTo("url1");
+        assertThat(modified.get(1)).isEqualTo("url");
+        assertThat(last.getPicturesUrl().get(0)).isEqualTo("url");
+        assertThat(last.getPicturesUrl().get(1)).isEqualTo("url1");
+
+
+    }
 
 
 }


### PR DESCRIPTION
# GM-159 UsedItemPicture에 Order 필드 생성하여 글 조회할 때 순서에 맞게 조회하도록 설정
## Description
> 사진을 설정한 순서에 맞게 조회

## PR Type
- [ ] Hotfix
- [ ] Other... Please describe :
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)

## Related Issues
- GM-87 중고 거래 글 수정
- GM-88 중고 거래 글 내용 보기

## Issues
중고 거래 사진에 순서 필드를 추가하여 글을 조회할 때, 순서에 맞게 사진을 보여주려 하였다.
생각한 방법으로는 2가지가 있었다.
1. UsedItemPictureRepo를 생성한 후, 쿼리에서 정렬을 한 후 UsedItemPost와 Picture을 연결해서 반환한다.
2. UsedItemPost를 조회를 위한 DTO로 전환 시에 list를 정렬한 후 반환한다.

현재 UsedItemPicture를 UsedItemPost에서 Cascade로 관리하고 있기 때문에 따로 Repo를 만드는 것은 기존 규칙을 헤칠 수 있을 것 같아서  2번 방법을 선택함.

UsedItemPicture에 Comparator를 구현하여 order로 서로 비교하도록 설정하였음.
```java
public class UsedItemPicture implements Comparable<UsedItemPicture>{
  @Override
    public int compareTo(UsedItemPicture o) {
        return this.order.compareTo(o.getOrder());
    }
}
```
그리고 실제로 dto로 전환하는 과정에서 사용되는 메서드에서 이를 정렬한 후 반환하도록 해주었다.
```java
public class UsedItemPost {
    public List<String> getPicturesUrl(){
        Collections.sort(pictures);
        return this.pictures.stream().map(UsedItemPicture::getUrl)
                .toList();
    }
}
```

#### 결과

아래 사진은 위에서부터 본래 상태, 변경할 내용, 변경 후를 볼 수 있다.
![image](https://user-images.githubusercontent.com/76154390/215432450-d47471c9-0130-490b-9066-2a995872cba4.png)

아래 사진은 새로운 이미지를 추가한 후에도 순서가 보장되는 것을 볼 수 있다.
새로운 사진의 자리인 0번, 2번 인덱스를 제외하면 기존의 순서와 같고, 새로운 사진도 역시 제자리를 찾아 간 것을 볼 수 있다.
 
![image](https://user-images.githubusercontent.com/76154390/215432624-4216ac6a-370a-459b-a773-629ecd25c576.png)


+++ 추가로 조회 메서드 작동 시 fetch join을 사용해 쿼리 성능을 향상시킴.

### Test
  
![image](https://user-images.githubusercontent.com/76154390/215433836-574df8a6-e5bb-4cd7-9868-7f01e8607d87.png)

*** 

## Related Files
- `UsedItemPost`
- `UsedItemPicture`
- `JpaUsedItemPostRepository`

## Think About..  
쿼리를 처음에 잘못 생각해서 시간을 많이 날렸다. 
1번과 2번에서 뭐가 더 좋은지는 잘 모르겠는데, 캐싱을 써보고 체크해봐야 할 것 같음.
## Conclusion  
> 처음부터 잘 생각해보면 이런 부분을 안놓쳤을텐데 아쉽다.
