### PR TITLE
GM-154 글 조회 시 TradeStatus 반환 추가

### DIFF
--- a/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
@@ -1,6 +1,7 @@
 package com.gaaji.useditem.controller.dto;
 
 import com.gaaji.useditem.adaptor.RetrieveResponse;
+import com.gaaji.useditem.domain.TradeStatus;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostCounter;
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ public class PostRetrieveResponse {
     private String sellerNickname;
     private double sellerMannerTemperature;
     private Boolean isMine;
+    private TradeStatus tradeStatus;
 
     private List<String> picturesUrl;
 
@@ -61,6 +63,7 @@ public class PostRetrieveResponse {
         this.sellerMannerTemperature = seller.getMannerTemperature();
         this.isMine = post.validateSellerId(authId);
         this.picturesUrl = post.getPicturesUrl();
+        this.tradeStatus = post.getTradeStatus();
 
     }
 

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -236,4 +236,7 @@ public class UsedItemPost {
     }
 
 
+    public TradeStatus getTradeStatus() {
+        return tradeStatus;
+    }
 }

--- a/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
+++ b/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
@@ -14,6 +14,7 @@ import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.Price;
 import com.gaaji.useditem.domain.SellerId;
 import com.gaaji.useditem.domain.Town;
+import com.gaaji.useditem.domain.TradeStatus;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostCounter;
 import com.gaaji.useditem.domain.UsedItemPostId;
@@ -76,6 +77,7 @@ class UsedItemPostRetrieveControllerTest {
                 .andExpect(jsonPath("$.sellerNickname").value("익명"))
                 .andExpect(jsonPath("$.sellerMannerTemperature").value(36.5))
                 .andExpect(jsonPath("$.isMine").value(true))
+                .andExpect(jsonPath("$.tradeStatus").value(TradeStatus.SELLING.name()))
                 .andDo(print());
 
 

--- a/src/test/java/com/gaaji/useditem/service/UsedItemPostRetrieveServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/service/UsedItemPostRetrieveServiceTest.java
@@ -11,6 +11,7 @@ import com.gaaji.useditem.domain.Post;
 import com.gaaji.useditem.domain.Price;
 import com.gaaji.useditem.domain.SellerId;
 import com.gaaji.useditem.domain.Town;
+import com.gaaji.useditem.domain.TradeStatus;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostCounter;
 import com.gaaji.useditem.domain.UsedItemPostId;
@@ -68,8 +69,7 @@ class UsedItemPostRetrieveServiceTest {
         assertThat(response.getChatCount()).isZero();
         assertThat(response.getSuggestCount()).isZero();
         assertThat(response.getInterestCount()).isZero();
-
-
+        assertThat(response.getTradeStatus()).isEqualTo(TradeStatus.SELLING);
     }
 
 }


### PR DESCRIPTION
# GM-154 글 조회 시 TradeStatus 반환 추가
## Description
> 중고거래 글 내용 조회할 때, 거래 상태 값을 함께 반환하도록 설정함.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-88 중고 거래 글 보기

## Issues
중고 거래 글 조회 시 반환 값에서 거래 상태 값이 빠져서 이를 추가해 주었다.
![image](https://user-images.githubusercontent.com/76154390/215673147-fdf13442-5423-4e20-9703-1c711e506147.png)

### Test
기존 테스트들에서 반환 값 추가함.

*** 

## Related Files
- `PostRetrieveResponse`

## Think About..  
왜 내가 이걸 빼먹었을까.. 싶지만 그럴 수 있다.
더블 체크 안한 수민씨 잘못이다...
## Conclusion  
> 나는 무죄
