### PR TITLE
GM-171 글 조회 시 판매자 프로필 사진 URL 반환 추가

### DIFF
--- a/src/main/java/com/gaaji/useditem/adaptor/RetrieveResponse.java
+++ b/src/main/java/com/gaaji/useditem/adaptor/RetrieveResponse.java
@@ -12,6 +12,7 @@ public class RetrieveResponse {
 
     private String authId;
     private String nickname;
+    private String pictureUrl;
     private double mannerTemperature;
 
 }

--- a/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
@@ -33,9 +33,11 @@ public class PostRetrieveResponse {
     private String townAddress;
     private String sellerId;
     private String sellerNickname;
+    private String sellerProfilePictureUrl;
     private double sellerMannerTemperature;
     private Boolean isMine;
     private TradeStatus tradeStatus;
+
 
     private List<String> picturesUrl;
 
@@ -64,6 +66,7 @@ public class PostRetrieveResponse {
         this.isMine = post.validateSellerId(authId);
         this.picturesUrl = post.getPicturesUrl();
         this.tradeStatus = post.getTradeStatus();
+        this.sellerProfilePictureUrl = seller.getPictureUrl();
 
     }
 

--- a/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
+++ b/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
@@ -49,7 +49,7 @@ class UsedItemPostRetrieveControllerTest {
                         SellerId.of("foo"), Post.of("foo","bar","foobar")
                 , Price.of(10000000L), true, WishPlace.of("","","")
                 , Town.of("foo","bar")), UsedItemPostCounter.of(UsedItemPostId.of("foo"), Counter.of())
-                , new RetrieveResponse("foo", "익명",36.5), "foo"));
+                , new RetrieveResponse("foo", "익명","foo",36.5), "foo"));
 
         //when
         mockMvc.perform(MockMvcRequestBuilders.get("/posts/123")
@@ -78,6 +78,7 @@ class UsedItemPostRetrieveControllerTest {
                 .andExpect(jsonPath("$.sellerMannerTemperature").value(36.5))
                 .andExpect(jsonPath("$.isMine").value(true))
                 .andExpect(jsonPath("$.tradeStatus").value(TradeStatus.SELLING.name()))
+                .andExpect(jsonPath("$.sellerProfilePictureUrl").value("foo"))
                 .andDo(print());
 
 

--- a/src/test/java/com/gaaji/useditem/impl/StubAuthServiceClient.java
+++ b/src/test/java/com/gaaji/useditem/impl/StubAuthServiceClient.java
@@ -7,6 +7,6 @@ public class StubAuthServiceClient implements AuthServiceClient {
 
     @Override
     public RetrieveResponse retrieveAuth(String authId) {
-       return new RetrieveResponse("foo", "익명", 36.5);
+       return new RetrieveResponse("foo", "익명","foo", 36.5);
     }
 }

--- a/src/test/java/com/gaaji/useditem/service/UsedItemPostRetrieveServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/service/UsedItemPostRetrieveServiceTest.java
@@ -70,6 +70,7 @@ class UsedItemPostRetrieveServiceTest {
         assertThat(response.getSuggestCount()).isZero();
         assertThat(response.getInterestCount()).isZero();
         assertThat(response.getTradeStatus()).isEqualTo(TradeStatus.SELLING);
+        assertThat(response.getSellerProfilePictureUrl()).isEqualTo("foo");
     }
 
 }


### PR DESCRIPTION
#GM-171 글 조회 시 판매자 프로필 사진 URL 반환 추가
## Description
> 중고 거래 글 조회 시 판매자의 프로필 사진을 조회할 수 있도록 리턴 값에 추가해주었다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-78 [회원서비스] 프로필 사진 설정

## Issues
회원 서비스에게 회원 정보를 조회할 때, 반환되는 객체에 프로필 사진 URL 필드를 추가하고, 글 조회 때 반환 DTO에도 프로필 사진 URL 필드를 추가하였다.
![image](https://user-images.githubusercontent.com/76154390/215682910-7e78b1e6-4073-4fd4-9d4b-d9944e4c7744.png)


### Test
기존에 존재하는 테스트에서 새로운 필드를 추가해주었음.
*** 

## Related Files
- `PostRetrieveResponse`
- `RetrieveResponse`

## Conclusion  
> 빼먹은 기능들은 대체로 다 끝나간 듯 싶다.
