### PR TITLE
Gm 163

### DIFF
--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
@@ -1,0 +1,5 @@
+package com.gaaji.useditem.applicationservice;
+
+public interface UsedItemPostUpdateTradeStatusService {
+
+}

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
@@ -1,5 +1,9 @@
 package com.gaaji.useditem.applicationservice;
 
+import com.gaaji.useditem.domain.TradeStatus;
+
 public interface UsedItemPostUpdateTradeStatusService {
+
+	void updateTradeStatus(String authId, String postId, String purchaserId, TradeStatus tradeStatus);
 
 }

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusService.java
@@ -6,4 +6,6 @@ public interface UsedItemPostUpdateTradeStatusService {
 
 	void updateTradeStatus(String authId, String postId, String purchaserId, TradeStatus tradeStatus);
 
+	void updateTradeStatusUnchangeable(String authId, String postId);
+
 }

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
@@ -9,6 +9,7 @@ import com.gaaji.useditem.domain.UsedItemPostId;
 import com.gaaji.useditem.exception.CanNotUpdateTradeStatusException;
 import com.gaaji.useditem.exception.NoMatchAuthIdAndSellerIdException;
 import com.gaaji.useditem.exception.NoSearchPostException;
+import com.gaaji.useditem.exception.TradeStatusIsNotFinishException;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,21 @@ public class UsedItemPostUpdateTradeStatusServiceImpl implements UsedItemPostUpd
 				usedItemPost.updateTradeStatus(tradeStatus, null);
 			} else {
 				usedItemPost.updateTradeStatus(tradeStatus, purchaserId);
+			}
+		} else {
+			throw new NoMatchAuthIdAndSellerIdException();
+		}
+	}
+
+	@Override
+	public void updateTradeStatusUnchangeable(String authId, String postId) {
+		UsedItemPost usedItemPost = this.usedItemPostRepository.findById(UsedItemPostId.of(postId)).orElseThrow(() -> new NoSearchPostException());
+		
+		if (usedItemPost.validateSellerId(authId)) {
+			if (usedItemPost.getTradeStatus().equals(TradeStatus.FINISH)) {
+				usedItemPost.updateTradeStatusUnchangeable();
+			}  else {
+				throw new TradeStatusIsNotFinishException();
 			}
 		} else {
 			throw new NoMatchAuthIdAndSellerIdException();

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.gaaji.useditem.domain.TradeStatus;
 import com.gaaji.useditem.domain.UsedItemPost;
 import com.gaaji.useditem.domain.UsedItemPostId;
+import com.gaaji.useditem.exception.CanNotUpdateTradeStatusException;
 import com.gaaji.useditem.exception.NoMatchAuthIdAndSellerIdException;
 import com.gaaji.useditem.exception.NoSearchPostException;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
@@ -25,7 +26,7 @@ public class UsedItemPostUpdateTradeStatusServiceImpl implements UsedItemPostUpd
 
 		if (usedItemPost.validateSellerId(authId)) {
 			if (usedItemPost.getTradeStatus().equals(TradeStatus.UNCHANGEABLE)) {
-				// TODO 에러 발생
+				throw new CanNotUpdateTradeStatusException();
 			} else if (tradeStatus.equals(TradeStatus.SELLING)) {
 				usedItemPost.updateTradeStatus(tradeStatus, null);
 			} else {

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
@@ -1,0 +1,15 @@
+package com.gaaji.useditem.applicationservice;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.gaaji.useditem.repository.UsedItemPostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UsedItemPostUpdateTradeStatusServiceImpl implements UsedItemPostUpdateTradeStatusService{
+
+}

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostUpdateTradeStatusServiceImpl.java
@@ -3,6 +3,11 @@ package com.gaaji.useditem.applicationservice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gaaji.useditem.domain.TradeStatus;
+import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import com.gaaji.useditem.exception.NoMatchAuthIdAndSellerIdException;
+import com.gaaji.useditem.exception.NoSearchPostException;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,6 +15,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 @Service
-public class UsedItemPostUpdateTradeStatusServiceImpl implements UsedItemPostUpdateTradeStatusService{
+public class UsedItemPostUpdateTradeStatusServiceImpl implements UsedItemPostUpdateTradeStatusService {
+
+	private final UsedItemPostRepository usedItemPostRepository;
+
+	@Override
+	public void updateTradeStatus(String authId, String postId, String purchaserId, TradeStatus tradeStatus) {
+		UsedItemPost usedItemPost = this.usedItemPostRepository.findById(UsedItemPostId.of(postId)).orElseThrow(() -> new NoSearchPostException());
+
+		if (usedItemPost.validateSellerId(authId)) {
+			if (usedItemPost.getTradeStatus().equals(TradeStatus.UNCHANGEABLE)) {
+				// TODO 에러 발생
+			} else if (tradeStatus.equals(TradeStatus.SELLING)) {
+				usedItemPost.updateTradeStatus(tradeStatus, null);
+			} else {
+				usedItemPost.updateTradeStatus(tradeStatus, purchaserId);
+			}
+		} else {
+			throw new NoMatchAuthIdAndSellerIdException();
+		}
+	}
 
 }

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemReverseHideServiceImpl.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemReverseHideServiceImpl.java
@@ -21,7 +21,7 @@ public class UsedItemReverseHideServiceImpl implements UsedItemReverseHideServic
 
 	@Override
 	public void reverseHide(String authId, String postId) {
-		UsedItemPost usedItemPost = this.usedItemPostRepository.findById(UsedItemPostId.of(postId)).orElseThrow(() -> new NoSearchPostException()); //TODO 여기도 예외 처리
+		UsedItemPost usedItemPost = this.usedItemPostRepository.findById(UsedItemPostId.of(postId)).orElseThrow(() -> new NoSearchPostException()); 
 		if(usedItemPost.validateSellerId(authId)) {
 			usedItemPost.reverseHide();
 		} else {

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
@@ -1,0 +1,14 @@
+package com.gaaji.useditem.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import com.gaaji.useditem.applicationservice.UsedItemPostUpdateTradeStatusService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+public class UsedItemPostUpdateTradeStatusController {
+
+	private final UsedItemPostUpdateTradeStatusService usedItemPostUpdateTradeStatusService;
+}

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
@@ -15,7 +15,7 @@ import com.gaaji.useditem.domain.TradeStatus;
 
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("/posts/TradeStatus")
+@RequestMapping("/posts/tradeStatus")
 @RequiredArgsConstructor
 @RestController
 public class UsedItemPostUpdateTradeStatusController {
@@ -29,7 +29,7 @@ public class UsedItemPostUpdateTradeStatusController {
         return ResponseEntity.ok().build();
     }
 	
-	@PatchMapping("/{postId}")
+	@PatchMapping("/unchangeable/{postId}")
     public ResponseEntity<Void> updateTradeStatusUnchangeable(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) { 
 		usedItemPostUpdateTradeStatusService.updateTradeStatusUnchangeable(authId, postId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
@@ -28,4 +28,10 @@ public class UsedItemPostUpdateTradeStatusController {
 		usedItemPostUpdateTradeStatusService.updateTradeStatus(authId, postId, purchaserId, tradeStatus);
         return ResponseEntity.ok().build();
     }
+	
+	@PatchMapping("/{postId}")
+    public ResponseEntity<Void> updateTradeStatusUnchangeable(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) { 
+		usedItemPostUpdateTradeStatusService.updateTradeStatusUnchangeable(authId, postId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
+++ b/src/main/java/com/gaaji/useditem/controller/UsedItemPostUpdateTradeStatusController.java
@@ -1,14 +1,31 @@
 package com.gaaji.useditem.controller;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gaaji.useditem.applicationservice.UsedItemPostUpdateTradeStatusService;
+import com.gaaji.useditem.controller.dto.PostUpdateRequest;
+import com.gaaji.useditem.domain.TradeStatus;
 
 import lombok.RequiredArgsConstructor;
 
+@RequestMapping("/posts/TradeStatus")
 @RequiredArgsConstructor
 @RestController
 public class UsedItemPostUpdateTradeStatusController {
 
 	private final UsedItemPostUpdateTradeStatusService usedItemPostUpdateTradeStatusService;
+	
+	@PatchMapping("/{postId}")
+    public ResponseEntity<Void> updateTradeStatus(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId, 
+    		@RequestBody String purchaserId, @RequestBody TradeStatus tradeStatus){
+		usedItemPostUpdateTradeStatusService.updateTradeStatus(authId, postId, purchaserId, tradeStatus);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gaaji/useditem/domain/TradeStatus.java
+++ b/src/main/java/com/gaaji/useditem/domain/TradeStatus.java
@@ -2,5 +2,5 @@ package com.gaaji.useditem.domain;
 
 public enum TradeStatus {
     // 판매중 예약중 거래완료
-    SELLING, RESERVATION, FINISH
+    SELLING, RESERVATION, FINISH, UNCHANGEABLE
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -163,6 +163,11 @@ public class UsedItemPost {
 
     }
 
+    public void updateTradeStatus(TradeStatus tradeStatus, String purchaserId) {
+		this.tradeStatus = tradeStatus;
+		this.purchaserId = PurchaserId.of(purchaserId);
+	}
+    
     public String getTitle() {
         return post.getTitle();
     }
@@ -216,6 +221,8 @@ public class UsedItemPost {
     public String getSellerId() {
         return this.sellerId.getId();
     }
-
+    public TradeStatus getTradeStatus() {
+        return tradeStatus;
+    }
 
 }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -168,6 +168,10 @@ public class UsedItemPost {
 		this.purchaserId = PurchaserId.of(purchaserId);
 	}
     
+    public void updateTradeStatusUnchangeable() {
+		this.tradeStatus = TradeStatus.UNCHANGEABLE;
+	}
+    
     public String getTitle() {
         return post.getTitle();
     }

--- a/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
+++ b/src/main/java/com/gaaji/useditem/domain/UsedItemPost.java
@@ -224,5 +224,9 @@ public class UsedItemPost {
     public TradeStatus getTradeStatus() {
         return tradeStatus;
     }
+    
+    public PurchaserId getPurchaserId() {
+        return purchaserId;
+    }
 
 }

--- a/src/main/java/com/gaaji/useditem/exception/CanNotUpdateTradeStatusException.java
+++ b/src/main/java/com/gaaji/useditem/exception/CanNotUpdateTradeStatusException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.CAN_NOT_UPDATE_TRADE_STATUS;
+
+public class CanNotUpdateTradeStatusException extends AbstractApiException{
+
+    public CanNotUpdateTradeStatusException() {
+        super(CAN_NOT_UPDATE_TRADE_STATUS);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/TradeStatusIsNotFinishException.java
+++ b/src/main/java/com/gaaji/useditem/exception/TradeStatusIsNotFinishException.java
@@ -1,0 +1,10 @@
+package com.gaaji.useditem.exception;
+
+import static com.gaaji.useditem.exception.UsedItemErrorCode.Trade_STATUS_IS_NOT_FINISH;
+
+public class TradeStatusIsNotFinishException extends AbstractApiException{
+
+    public TradeStatusIsNotFinishException() {
+        super(Trade_STATUS_IS_NOT_FINISH);
+    }
+}

--- a/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
+++ b/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
@@ -44,8 +44,8 @@ public enum UsedItemErrorCode implements ErrorCode {
     RESERVATION_STATUS_CHANGE_PRICE(HttpStatus.BAD_REQUEST,"u-0013","예약 중엔 가격을 변경할 수 없습니다."),
 
     BOTH_SIZE_DOSE_NOT_MATCHED(HttpStatus.BAD_REQUEST,"u-0014","인덱스의 개수와 파일의 개수가 맞지 않습니다."),
-    INDEX_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST,"u-0015","인덱스가 범위를 초과했습니다.")
-    ,
+    INDEX_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST,"u-0015","인덱스가 범위를 초과했습니다."),
+    CAN_NOT_UPDATE_TRADE_STATUS(HttpStatus.BAD_REQUEST,"u-0016","거래 상태를 변경 할 수 없습니다."),
 
     ;
 	

--- a/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
+++ b/src/main/java/com/gaaji/useditem/exception/UsedItemErrorCode.java
@@ -46,7 +46,7 @@ public enum UsedItemErrorCode implements ErrorCode {
     BOTH_SIZE_DOSE_NOT_MATCHED(HttpStatus.BAD_REQUEST,"u-0014","인덱스의 개수와 파일의 개수가 맞지 않습니다."),
     INDEX_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST,"u-0015","인덱스가 범위를 초과했습니다."),
     CAN_NOT_UPDATE_TRADE_STATUS(HttpStatus.BAD_REQUEST,"u-0016","거래 상태를 변경 할 수 없습니다."),
-
+    Trade_STATUS_IS_NOT_FINISH(HttpStatus.BAD_REQUEST,"u-0016","거래 완료가 되지 않아 상태를 변경 할 수 없습니다."),
     ;
 	
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/gaaji/useditem/service/UpdateTradeStatusServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/service/UpdateTradeStatusServiceTest.java
@@ -1,0 +1,78 @@
+package com.gaaji.useditem.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.useditem.applicationservice.UsedItemDeleteService;
+import com.gaaji.useditem.applicationservice.UsedItemPostUpdateTradeStatusService;
+import com.gaaji.useditem.domain.Counter;
+import com.gaaji.useditem.domain.Post;
+import com.gaaji.useditem.domain.Price;
+import com.gaaji.useditem.domain.PurchaserId;
+import com.gaaji.useditem.domain.SellerId;
+import com.gaaji.useditem.domain.Town;
+import com.gaaji.useditem.domain.TradeStatus;
+import com.gaaji.useditem.domain.UsedItemPost;
+import com.gaaji.useditem.domain.UsedItemPostCounter;
+import com.gaaji.useditem.domain.UsedItemPostId;
+import com.gaaji.useditem.exception.CanNotUpdateTradeStatusException;
+import com.gaaji.useditem.exception.NoSearchPostCounterException;
+import com.gaaji.useditem.exception.NoSearchPostException;
+import com.gaaji.useditem.repository.JpaUsedItemPostCounterRepository;
+import com.gaaji.useditem.repository.JpaUsedItemPostRepository;
+
+@Transactional
+@SpringBootTest
+public class UpdateTradeStatusServiceTest {
+
+	@Autowired
+    JpaUsedItemPostRepository jpaUsedItemPostRepository;
+	@Autowired
+	JpaUsedItemPostCounterRepository jpaUsedItemPostCounterRepository;
+    @Autowired
+    UsedItemPostUpdateTradeStatusService usedItemPostUpdateTradeStatusService;
+    
+    @Test
+    void 삭제서비스 () throws Exception{
+        //given
+
+    	UsedItemPost usedItemPost = UsedItemPost.of(
+                UsedItemPostId.of("foo"),
+                SellerId.of("bar")
+                , Post.of("title", "contents", "category"), Price.of(1000L)
+                ,true, null, Town.of("townID", "address")
+        );
+
+        //when
+        jpaUsedItemPostRepository.save(usedItemPost);
+        UsedItemPost find = jpaUsedItemPostRepository.findById(UsedItemPostId.of("foo")).get();
+        UsedItemPostCounter counter = UsedItemPostCounter.of( UsedItemPostId.of("foo"), Counter.of());
+        this.jpaUsedItemPostCounterRepository.save(counter);
+
+
+        usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "aaa", TradeStatus.RESERVATION);
+        assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.RESERVATION);
+        assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of("aaa"));
+        
+        usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "bbb", TradeStatus.SELLING);
+        assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.SELLING);
+        assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of(null));
+        
+        usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "ccc", TradeStatus.UNCHANGEABLE);
+        assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.UNCHANGEABLE);
+        assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of("ccc"));
+        
+		assertThatThrownBy(()->usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "aaa", TradeStatus.FINISH)).isInstanceOf(CanNotUpdateTradeStatusException.class);
+        
+        
+
+    }
+// 변경 불가는 판매 완료에서만 변경이 가능하다
+  
+}

--- a/src/test/java/com/gaaji/useditem/service/UpdateTradeStatusServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/service/UpdateTradeStatusServiceTest.java
@@ -24,6 +24,7 @@ import com.gaaji.useditem.domain.UsedItemPostId;
 import com.gaaji.useditem.exception.CanNotUpdateTradeStatusException;
 import com.gaaji.useditem.exception.NoSearchPostCounterException;
 import com.gaaji.useditem.exception.NoSearchPostException;
+import com.gaaji.useditem.exception.TradeStatusIsNotFinishException;
 import com.gaaji.useditem.repository.JpaUsedItemPostCounterRepository;
 import com.gaaji.useditem.repository.JpaUsedItemPostRepository;
 
@@ -39,7 +40,7 @@ public class UpdateTradeStatusServiceTest {
     UsedItemPostUpdateTradeStatusService usedItemPostUpdateTradeStatusService;
     
     @Test
-    void 삭제서비스 () throws Exception{
+    void 상태변경 () throws Exception{
         //given
 
     	UsedItemPost usedItemPost = UsedItemPost.of(
@@ -64,12 +65,19 @@ public class UpdateTradeStatusServiceTest {
         assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.SELLING);
         assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of(null));
         
-        usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "ccc", TradeStatus.UNCHANGEABLE);
+		assertThatThrownBy(()->usedItemPostUpdateTradeStatusService.updateTradeStatusUnchangeable("bar", "foo")).isInstanceOf(TradeStatusIsNotFinishException.class);
+
+        
+		usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "ccc", TradeStatus.FINISH);
+        assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.FINISH);
+        assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of("ccc"));
+		
+        usedItemPostUpdateTradeStatusService.updateTradeStatusUnchangeable("bar", "foo");
         assertThat(find.getTradeStatus()).isEqualTo(TradeStatus.UNCHANGEABLE);
         assertThat(find.getPurchaserId()).isEqualTo(PurchaserId.of("ccc"));
         
 		assertThatThrownBy(()->usedItemPostUpdateTradeStatusService.updateTradeStatus("bar", "foo", "aaa", TradeStatus.FINISH)).isInstanceOf(CanNotUpdateTradeStatusException.class);
-        
+
         
 
     }


### PR DESCRIPTION
# GM 163 중고거래 글 상태 변환
## Description
> 중고거래 글의 거래 상태를 조건에 따라 변경을 해주었다.

## PR Type
- [ ] Hotfix
- [ v] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM 165 판매 중, 판매 완료, 예약 중 상태 변경
- GM 166 거래 불가로 상태 변경
 
## Issues
변경불가 상태일 때에는 변경이 불가능 하도록 하였고
판매 중 상태로 변경 할 때에는 구매자를 초기화 해 주었다.

거래 불가로 변경하는 경우는 다른 상태로 변경하는 코드와 비슷하지만 나중에 거래 후기 등의 기능과 맞물려서 코드가 변경될 가능성이 있기 때문에 분리를 했다.
<img width="799" alt="image" src="https://user-images.githubusercontent.com/48744386/215711197-3472af65-313c-49e9-92d3-c4faf9c1d015.png">

### Test
  
*** 테스트는 최대한 다양한 경우로 테스트를 해서 문제가 없도록 했다.
<img width="823" alt="image" src="https://user-images.githubusercontent.com/48744386/215711646-5e37345e-c940-4632-aca6-7359e3cbe5a8.png">


## Related Files
- UsedItemPostUpdateTradeStatusServiceImpl
- UsedItemPostUpdateTradeStatusService
- UsedItemPostUpdateTradeStatusServiceController
- 

## Think About..  
서비스 쪽에서 예외 처리를 해 놓기는 했지만 나중에 프론트가 구현 될 경우 프론트에서 거래불가 상태인 경우에는 상태를 바꿀 수 없도록 해야 하고 거래 완료가 되지 않으면 거래 불가로 변경하는 코드가 실행되지 않도록 해야한다.
+코드가 간단한 편이라 메소드로 분리 안하고 중첩 if문을 사용 했는데 더 좋은 방법이 있으면 좋을 듯하다.

## Conclusion  
> 상태 변경 완료