### PR TITLE
GM-209 중고거래 글 조회 시 관심 유무 조회하기

### DIFF
--- a/src/main/java/com/gaaji/useditem/adaptor/InterestServiceClient.java
+++ b/src/main/java/com/gaaji/useditem/adaptor/InterestServiceClient.java
@@ -1,0 +1,14 @@
+package com.gaaji.useditem.adaptor;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient("interest-service")
+public interface InterestServiceClient {
+
+    @GetMapping("/interest/post/{postId}/user/{userId}")
+    Boolean isExistInterest(@PathVariable("postId") String postId,
+            @PathVariable("userId") String userId, @RequestParam(name = "type") String postType);
+}

--- a/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostRetrieveService.java
+++ b/src/main/java/com/gaaji/useditem/applicationservice/UsedItemPostRetrieveService.java
@@ -1,7 +1,10 @@
 package com.gaaji.useditem.applicationservice;
 
 
+import static com.gaaji.useditem.config.Constants.POST_TYPE;
+
 import com.gaaji.useditem.adaptor.AuthServiceClient;
+import com.gaaji.useditem.adaptor.InterestServiceClient;
 import com.gaaji.useditem.adaptor.RetrieveResponse;
 import com.gaaji.useditem.applicationservice.UsedItemPostViewCountIncreaseService;
 import com.gaaji.useditem.controller.dto.PostRetrieveResponse;
@@ -11,6 +14,7 @@ import com.gaaji.useditem.domain.UsedItemPostId;
 import com.gaaji.useditem.exception.NoSearchPostException;
 import com.gaaji.useditem.repository.UsedItemPostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +26,8 @@ public class UsedItemPostRetrieveService {
     private final UsedItemPostRepository usedItemPostRepository;
     private final AuthServiceClient authServiceClient;
     private final UsedItemPostViewCountIncreaseService usedItemPostViewCountIncreaseService;
+    private final InterestServiceClient interestServiceClient;
+
 
 
     public PostRetrieveResponse retrievePost(String postId, String authId) {
@@ -32,8 +38,11 @@ public class UsedItemPostRetrieveService {
                 UsedItemPostId.of(postId));
 
         RetrieveResponse sellerInfo = authServiceClient.retrieveAuth(usedItemPost.getSellerId());
+        Boolean existInterest = interestServiceClient.isExistInterest(postId, authId,
+                POST_TYPE.getValue());
 
-        return PostRetrieveResponse.of(usedItemPost,counter,sellerInfo,authId);
+
+        return PostRetrieveResponse.of(usedItemPost,counter,sellerInfo,authId,existInterest);
     }
 
 

--- a/src/main/java/com/gaaji/useditem/config/Constants.java
+++ b/src/main/java/com/gaaji/useditem/config/Constants.java
@@ -1,0 +1,21 @@
+package com.gaaji.useditem.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RequiredArgsConstructor
+@Getter
+public enum Constants {
+
+    POST_TYPE("USEDITEM")
+
+
+
+    ;
+
+
+    private final String value;
+
+
+}

--- a/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
+++ b/src/main/java/com/gaaji/useditem/controller/dto/PostRetrieveResponse.java
@@ -37,15 +37,15 @@ public class PostRetrieveResponse {
     private double sellerMannerTemperature;
     private Boolean isMine;
     private TradeStatus tradeStatus;
+    private Boolean isInterested;
 
 
     private List<String> picturesUrl;
 
     private PostRetrieveResponse(UsedItemPost post, UsedItemPostCounter counter, RetrieveResponse seller,
-            String authId){
+            String authId,boolean isInterested){
         this.postId = post.getUsedItemPostId();
         this.suggestCount = counter.getSuggestCount();
-        this.interestCount = counter.getInterestCount();
         this.viewCount = counter.getViewCount();
         this.chatCount = counter.getChatCount();
         this.title = post.getTitle();
@@ -67,11 +67,16 @@ public class PostRetrieveResponse {
         this.picturesUrl = post.getPicturesUrl();
         this.tradeStatus = post.getTradeStatus();
         this.sellerProfilePictureUrl = seller.getPictureUrl();
-
+        this.isInterested = isInterested;
+        this.interestCount = counter.getInterestCount();
+        if (isInterested && counter.getInterestCount() == 0) {
+            this.interestCount = 1;
+        }
     }
 
-    public static PostRetrieveResponse of (UsedItemPost post, UsedItemPostCounter counter, RetrieveResponse seller, String authId){
-        return new PostRetrieveResponse(post, counter, seller, authId );
+    public static PostRetrieveResponse of (UsedItemPost post, UsedItemPostCounter counter, RetrieveResponse seller, String authId
+    , boolean isInterested){
+        return new PostRetrieveResponse(post, counter, seller, authId , isInterested);
 
     }
 

--- a/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
+++ b/src/test/java/com/gaaji/useditem/controller/UsedItemPostRetrieveControllerTest.java
@@ -42,14 +42,55 @@ class UsedItemPostRetrieveControllerTest {
     UsedItemPostRetrieveService usedItemPostRetrieveService;
 
     @Test
-    void 정상_글내용보기() throws Exception {
+    void 정상_글내용보기_관심O() throws Exception {
         //given
         given(usedItemPostRetrieveService.retrievePost(anyString(), anyString()))
                 .willReturn(PostRetrieveResponse.of(UsedItemPost.of(UsedItemPostId.of("foo"),
                         SellerId.of("foo"), Post.of("foo","bar","foobar")
                 , Price.of(10000000L), true, WishPlace.of("","","")
                 , Town.of("foo","bar")), UsedItemPostCounter.of(UsedItemPostId.of("foo"), Counter.of())
-                , new RetrieveResponse("foo", "익명","foo",36.5), "foo"));
+                , new RetrieveResponse("foo", "익명","foo",36.5), "foo", true));
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.get("/posts/123")
+                        .header(HttpHeaders.AUTHORIZATION, "foo")
+                        .header("X-TOWN-TOKEN", "bar"))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postId").value("foo"))
+                .andExpect(jsonPath("$.viewCount").value(0))
+                .andExpect(jsonPath("$.chatCount").value(0))
+                .andExpect(jsonPath("$.interestCount").value(1))
+                .andExpect(jsonPath("$.suggestCount").value(0))
+                .andExpect(jsonPath("$.title").value("foo"))
+                .andExpect(jsonPath("$.contents").value("bar"))
+                .andExpect(jsonPath("$.category").value("foobar"))
+                .andExpect(jsonPath("$.isHide").value(false))
+                .andExpect(jsonPath("$.price").value(10000000))
+                .andExpect(jsonPath("$.canSuggest").value(true))
+                .andExpect(jsonPath("$.wishX").value(""))
+                .andExpect(jsonPath("$.wishY").value(""))
+                .andExpect(jsonPath("$.wishText").value(""))
+                .andExpect(jsonPath("$.townId").value("foo"))
+                .andExpect(jsonPath("$.townAddress").value("bar"))
+                .andExpect(jsonPath("$.sellerId").value("foo"))
+                .andExpect(jsonPath("$.sellerNickname").value("익명"))
+                .andExpect(jsonPath("$.sellerMannerTemperature").value(36.5))
+                .andExpect(jsonPath("$.isMine").value(true))
+                .andExpect(jsonPath("$.tradeStatus").value(TradeStatus.SELLING.name()))
+                .andExpect(jsonPath("$.sellerProfilePictureUrl").value("foo"))
+                .andExpect(jsonPath("$.isInterested").value(true))
+                .andDo(print());
+    }
+    @Test
+    void 정상_글내용보기_관심X() throws Exception {
+        //given
+        given(usedItemPostRetrieveService.retrievePost(anyString(), anyString()))
+                .willReturn(PostRetrieveResponse.of(UsedItemPost.of(UsedItemPostId.of("foo"),
+                                SellerId.of("foo"), Post.of("foo","bar","foobar")
+                                , Price.of(10000000L), true, WishPlace.of("","","")
+                                , Town.of("foo","bar")), UsedItemPostCounter.of(UsedItemPostId.of("foo"), Counter.of())
+                        , new RetrieveResponse("foo", "익명","foo",36.5), "foo", false));
 
         //when
         mockMvc.perform(MockMvcRequestBuilders.get("/posts/123")
@@ -79,12 +120,8 @@ class UsedItemPostRetrieveControllerTest {
                 .andExpect(jsonPath("$.isMine").value(true))
                 .andExpect(jsonPath("$.tradeStatus").value(TradeStatus.SELLING.name()))
                 .andExpect(jsonPath("$.sellerProfilePictureUrl").value("foo"))
+                .andExpect(jsonPath("$.isInterested").value(false))
                 .andDo(print());
-
-
-
-
-
     }
 
 

--- a/src/test/java/com/gaaji/useditem/impl/StubInterestServiceClientReturnFalse.java
+++ b/src/test/java/com/gaaji/useditem/impl/StubInterestServiceClientReturnFalse.java
@@ -1,0 +1,11 @@
+package com.gaaji.useditem.impl;
+
+import com.gaaji.useditem.adaptor.InterestServiceClient;
+
+public class StubInterestServiceClientReturnFalse implements InterestServiceClient {
+
+    @Override
+    public Boolean isExistInterest(String postId, String userId, String postType) {
+        return false;
+    }
+}

--- a/src/test/java/com/gaaji/useditem/impl/StubInterestServiceClientReturnTrue.java
+++ b/src/test/java/com/gaaji/useditem/impl/StubInterestServiceClientReturnTrue.java
@@ -1,0 +1,11 @@
+package com.gaaji.useditem.impl;
+
+import com.gaaji.useditem.adaptor.InterestServiceClient;
+
+public class StubInterestServiceClientReturnTrue implements InterestServiceClient {
+
+    @Override
+    public Boolean isExistInterest(String postId, String userId, String postType) {
+        return true;
+    }
+}

--- a/src/test/java/com/gaaji/useditem/service/findPostListServiceTest.java
+++ b/src/test/java/com/gaaji/useditem/service/findPostListServiceTest.java
@@ -12,6 +12,7 @@ import javax.transaction.Transactional;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -49,6 +50,12 @@ public class findPostListServiceTest {
 	JpaUsedItemPostRepository jpaUsedItemPostRepository;
 	@Autowired
 	JpaUsedItemPostCounterRepository jpaUsedItemPostCounterRepository;
+
+	@BeforeEach
+	void beforeEach(){
+		jpaUsedItemPostRepository.deleteAll();;
+		jpaUsedItemPostCounterRepository.deleteAll();;
+	}
 
 	@Test
 	void 조회리스트서비스() throws Exception {


### PR DESCRIPTION
# GM-209 중고거래 글 조회 시 관심 유무 조회하기
## Description
> 중고 거래 글을 조회할 때, 관심 선택 유무를 함께 반환해준다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-210

## Issues

중고 거래 글을 조회할 때, 관심 선택 유무를 함께 반환해준다.
이때 관심은 TRUE인데 관심 카운트가 0일 경우에 대한 예외 처리를 고민하였으나,
에러 메세지를 반환하면서 페이지를 보여주지 않을 정도로 심각한 에러는 아니라고 판단하여 
DTO에서의 관심 카운트 값을 +1해서 보내주기로 하였따.

카프카가 결과적으로 정합성을 유지하는 서비스이기 때문에, 이런 케이스가 발생할 수 있다고 생각했음.


### Test
  
![image](https://user-images.githubusercontent.com/76154390/217194890-bc69f393-4666-4bc4-bab2-3dcff4211367.png)

*** 

## Related Files
- `InterestServiceClient`
- `PostRetrieveResponse`

## Conclusion  
> 저장을 생활화 해라
